### PR TITLE
Waive the integration suite for prose-only pull requests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
     "IAAAOHAAA",
     "JHEVJR",
     "kxoaa",
+    "lycheeverse",
     "mxzcaorwojadh",
     "rreading",
     "UMSKPI",

--- a/.cspell.json
+++ b/.cspell.json
@@ -182,6 +182,7 @@
     "dkms",
     "dlpriority",
     "dltypes",
+    "DOCKERHUB",
     "Dockerfiles",
     "donjayamanne",
     "dorama",

--- a/.cspell.json
+++ b/.cspell.json
@@ -31,7 +31,6 @@
     "IAAAOHAAA",
     "JHEVJR",
     "kxoaa",
-    "lycheeverse",
     "mxzcaorwojadh",
     "rreading",
     "UMSKPI",

--- a/.env.example
+++ b/.env.example
@@ -299,14 +299,14 @@ NZBGET_PROFILE=disabled
 
 ### VERSIONS
 # Lines without a # renovate: annotation use floating/channel tags managed manually.
-# renovate: depName=lscr.io/linuxserver/bazarr
+# renovate: depName=docker.io/linuxserver/bazarr
 BAZARR_VERSION=1.5.6@sha256:047222423d6d8556a88581b189175bec57f286f120b52ba29c0390fe6babaa5a
 CADVISOR_VERSION=v0.52.1@sha256:f40e65878e25c2e78ea037f73a449527a0fb994e303dc3e34cb6b187b4b91435
 # renovate: depName=ghcr.io/advplyr/audiobookshelf
 AUDIOBOOKSHELF_VERSION=2.34.0@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
-# renovate: depName=lscr.io/linuxserver/calibre
+# renovate: depName=docker.io/linuxserver/calibre
 CALIBRE_VERSION=9.8.0@sha256:de295215232855535ec110855d2f74946c7d78a596eb3a9d39d191e21dbc6fcc
-# renovate: depName=lscr.io/linuxserver/calibre-web
+# renovate: depName=docker.io/linuxserver/calibre-web
 CALIBREWEB_VERSION=0.6.26@sha256:7c0464228f2fdcf543b46e5327f36114596b097db6af0297c26b0452ed15f17c
 # renovate: datasource=docker depName=ghcr.io/nperez0111/koreader-sync
 KORSYNC_VERSION=sha-7bcefd34e9f6738ce34ccda338aedd316baa05c9@sha256:c59b4b79531452ca98a05f72143f5d7a318eca23ebde86404f15c5f257d9a129
@@ -316,25 +316,25 @@ FLARESOLVERR_VERSION=v3.4.6@sha256:7962759d99d7e125e108e0f5e7f3cdbcd36161776d058
 HOMEPAGE_VERSION=v1.12.3@sha256:cc84f2f5eb3c7734353701ccbaa24ed02dacb0d119114e50e4251e2005f3990a
 # renovate: depName=docker.io/grafana/grafana-oss
 GRAFANA_VERSION=11.1.3@sha256:420dfcbe22c71da8774b82b2e9ece02382fa210174bb8f342c922d04afdc0f0f
-# renovate: depName=lscr.io/linuxserver/jellyfin
+# renovate: depName=docker.io/linuxserver/jellyfin
 JELLYFIN_VERSION=10.10.3@sha256:d53c3a6808d009b0bb695623245fd806f8a582923817a5bf18a161f53458a72c
 # renovate: depName=linuxserver/lazylibrarian versioning=loose
 LAZYLIBRARIAN_VERSION=40a389ea-ls309
-# renovate: depName=lscr.io/linuxserver/lidarr
+# renovate: depName=docker.io/linuxserver/lidarr
 LIDARR_VERSION=3.1.0@sha256:2e4cdc7c8d5fa36915f446a29976ee01d3f9cc9722b8530a09121c76fbabef55
 MYLAR_VERSION=v0.9.0-ls252
 NGINX_VERSION=stable-alpine
 NGINX_EXPORTER_VERSION=1.4.0@sha256:a5a1e3ee01c1456c6c690ca05d5bcb1eac65753e66e3e9951317284b34190edd
 NODE_EXPORTER_VERSION=v1.11.1@sha256:e9cff4fc67b1818f8c97adb115b9f12c9a54b533de86765d4a0effc01b357205
 NOTIFIARR_VERSION=v0.9.5-alpine
-# renovate: depName=lscr.io/linuxserver/nzbget versioning=loose
+# renovate: depName=docker.io/linuxserver/nzbget versioning=loose
 NZBGET_VERSION=24.1.20240515@sha256:532421686b08fcf03220b96b6405f9b903a692c6d728ddb77c808a4286480a77
-# renovate: depName=lscr.io/linuxserver/nzbhydra2
+# renovate: depName=docker.io/linuxserver/nzbhydra2
 NZBHYDRA2_VERSION=8.8.1@sha256:4ff03448e36fd653842b81b398ba686da4bd9fcd9edf1f78fc5a07eef64a2caa
 PLEX_VERSION=latest
 PODMAN_LIMITS_EXPORTER_VERSION=3.13-alpine3.22@sha256:e81548ac35b07a3bd4805f275107592ef458b1e893c0e04d45aedaa19416cca5
 PODMAN_EXPORTER_VERSION=v1.20.0@sha256:14ce7addbc7348875b3f74a6002def96b66e2b1eb5efb4bdecf8037b868ae0ee
-# renovate: depName=quay.io/prometheus/prometheus
+# renovate: depName=docker.io/prom/prometheus
 PROMETHEUS_VERSION=v2.53.2@sha256:cafe963e591c872d38f3ea41ff8eb22cee97917b7c97b5c0ccd43a419f11f613
 ALLOY_VERSION=v1.16.0@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8
 # renovate: depName=docker.io/grafana/loki
@@ -342,23 +342,23 @@ LOKI_VERSION=3.7.1@sha256:73e905b51a7f917f7a1075e4be68759df30226e03dcb3cd2213b98
 LOG_ROTATOR_VERSION=3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 # renovate: depName=ghcr.io/qdm12/gluetun
 GLUETUN_VERSION=v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab
-# renovate: depName=lscr.io/linuxserver/prowlarr
+# renovate: depName=docker.io/linuxserver/prowlarr
 PROWLARR_VERSION=2.5.2@sha256:1295cff29d10b486c0d8324d1559a552140a5932bf8b3d87e398654414f63f92
-# renovate: depName=lscr.io/linuxserver/qbittorrent
+# renovate: depName=docker.io/linuxserver/qbittorrent
 QBITTORRENT_VERSION=5.1.4@sha256:c9990949e968e99333f47f49da7d16e81ba6e1469c8c46807a65b984c9e8b6ff
 QBITTORRENT_EXPORTER_VERSION=v1.6.0@sha256:b987d19693a5b2fe7314b22009c6302e084ec801fcf96afaf14065b4cdafc842
-# renovate: depName=lscr.io/linuxserver/radarr
+# renovate: depName=docker.io/linuxserver/radarr
 RADARR_VERSION=6.3.0@sha256:a45b5ab0f850f39edb4cc9c95bbd967b52ddc3d4574a4dfb45561177db6c88f4
-# renovate: depName=lscr.io/linuxserver/readarr versioning=loose
+# renovate: depName=docker.io/linuxserver/readarr versioning=loose
 READARR_VERSION=0.4.19-nightly@sha256:4f291128d1a5538be73c2a30473d7cdd0820e223dc8b8533b0cbc5659000dcbe
 # renovate: depName=ghcr.io/recyclarr/recyclarr
 RECYCLARR_VERSION=8.5.1@sha256:734cecf44ae9be7cf0cb05b2c1bc7da0abef9d938cc11b605e58b3146205e5c0
-# renovate: depName=lscr.io/linuxserver/sabnzbd
+# renovate: depName=docker.io/linuxserver/sabnzbd
 SABNZBD_VERSION=5.0.1@sha256:c65265edbfb42a1e4b6c68d3926e4aab4cf9cf185be1fafd1a692cb195cc9b0e
 SABNZBD_EXPORTER_VERSION=0.1.80@sha256:8404e51064aca68c533f3f56827c054f8eac3bad8066827e904c1769a15366ab
-# renovate: depName=lscr.io/linuxserver/sonarr
+# renovate: depName=docker.io/linuxserver/sonarr
 SONARR_VERSION=4.0.19@sha256:373159ba768e23a3a1c497d9f2b936addf8fd5b1fdce7dd6a14080ac928bfda0
-# renovate: depName=lscr.io/linuxserver/wireguard
+# renovate: depName=docker.io/linuxserver/wireguard
 VPN_MOCK_VERSION=1.0.20260223-r0-ls119@sha256:ac43e1226878d2611315172d6ea357a95cb326ee73124b91108118efc8666889
 WHISPARR_VERSION=v3
 

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -5,12 +5,18 @@ name: Comment-Triggered Checks
 # head without needing a new push:
 #   /run-check  -> pre-commit and MegaLinter (PR Validation's pr_check job and
 #                  the megalinter job that follows it, via job_scope: checks)
-#   /run-tests  -> the test suite (PR Validation's prerequisites +
-#                  integration jobs, via job_scope: tests)
 #
-# /run-tests is not just a convenience any more: integration no longer runs on
-# a push at all, so this is the only way to ask for it. The author_association
-# check below is therefore the gate on who can spend that runner time.
+# There is deliberately no /run-tests here. The integration suite is started by
+# the `run-tests` label, and a label applied by this workflow's GITHUB_TOKEN
+# does not trigger anything: GitHub suppresses workflow runs from events its own
+# token creates, to stop workflows looping. Confirmed live on PR #41, where the
+# label was applied, the labeled event was swallowed, and nothing ran until the
+# same label was applied by a person.
+#
+# workflow_dispatch is the documented exception to that rule, which is why
+# /run-check still works while /run-tests could not. Apply the label instead,
+# from the sidebar or `gh pr edit <n> --add-label run-tests`; only collaborators
+# can, so the permission model is the same and there is no token to hold.
 # This job never checks out the PR's own code or workflow definitions: it
 # only reads PR metadata via the API and dispatches the target workflows
 # (always their trusted main-branch copies, workflow_dispatch requires
@@ -32,7 +38,7 @@ jobs:
     timeout-minutes: 2
     if: >
       github.event.issue.pull_request != null &&
-      (startsWith(github.event.comment.body, '/run-check') || startsWith(github.event.comment.body, '/run-tests')) &&
+      startsWith(github.event.comment.body, '/run-check') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     steps:
       - name: Acknowledge
@@ -51,22 +57,3 @@ jobs:
             --ref "${{ github.event.repository.default_branch }}" \
             -f pr_number="${{ github.event.issue.number }}" \
             -f job_scope=checks
-
-      # Labels rather than dispatches. A workflow_dispatch run is dispatched off
-      # main, so its check attaches to main's HEAD, while a required status
-      # check is evaluated against the pull request's head commit: the tests
-      # would run, pass, and leave the pull request blocked regardless. Applying
-      # the label fires a pull_request event against the right commit, so the
-      # result counts for the merge.
-      #
-      # Removed first, and the failure ignored, so that asking twice works: a
-      # label that is already present fires nothing when added again.
-      - name: Label for tests
-        if: startsWith(github.event.comment.body, '/run-tests')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" --remove-label run-tests || true
-          gh pr edit "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" --add-label run-tests

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -334,6 +334,10 @@ jobs:
       && (needs.prerequisites.result == 'success' || needs.prerequisites.result == 'skipped') }}
     env:
       PROTONVPN_PRIVATE_KEY: ${{ secrets.PROTONVPN_PRIVATE_KEY }}
+    permissions:
+      contents: read
+      # To take the label back off again, see the last step.
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -508,6 +512,24 @@ jobs:
         if: always()
         timeout-minutes: 5
         run: make stop_all
+
+      - name: Take the label back off
+        # The label means "run the suite once, now", so it is consumed rather
+        # than left on. Otherwise it lingers on the pull request and starts a
+        # twelve minute run again the moment anything fires this workflow:
+        # reopening a closed pull request would do it, since the label lives on
+        # the pull request rather than the branch and `reopened` is a trigger.
+        #
+        # Removing it fires `unlabeled`, which is deliberately not a trigger, so
+        # this cannot loop. always(), so a failed or cancelled run does not leave
+        # the label stuck and unable to be re-applied.
+        if: always() && github.event_name == 'pull_request'
+        timeout-minutes: 2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --remove-label run-tests || true
 
   # The required status check, and the only job here named "Integration Tests".
   # The suite itself is "Integration Suite" above.

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -212,6 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      code: ${{ steps.filter.outputs.code }}
       renovate: ${{ steps.filter.outputs.renovate }}
     steps:
       - name: Checkout
@@ -227,8 +228,24 @@ jobs:
           # them. The default is `some`, under which `**` alone matches
           # everything and the negations below never get a say, so `code` came
           # out true for a docs-only PR and the filter was decorative.
+          # Every predicate has to hold for a path to count, not just one of
+          # them. The default is `some`, under which `**` alone matches
+          # everything and the negations below never get a say, so `code` came
+          # out true for a docs-only PR and the filter was decorative.
           predicate-quantifier: every
+          # Anything that can change how the stack behaves at runtime. Read by
+          # the integration_required gate, which waives the suite when nothing
+          # here changed: a pull request touching only prose cannot break an
+          # integration test, and an eleven minute stack run to prove that costs
+          # more than the check is worth. Deliberately broad, so it lists what is
+          # safe to skip on rather than what to run on.
           filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!**/.gitkeep'
+              - '!CITATION.cff'
             renovate:
               - '.github/renovate.json5'
 
@@ -502,7 +519,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [integration]
+    needs: [integration, changes]
     # Not always(): a cancelled run is superseded by a newer one, and failing
     # here would just report a stale contradiction of it.
     if: ${{ !cancelled() }}
@@ -510,12 +527,36 @@ jobs:
       - name: Require the suite to have passed on this commit
         env:
           RESULT: ${{ needs.integration.result }}
+          # Empty unless the changes job both ran and answered, so a skipped or
+          # failed filter reads as "not proven docs-only" and the suite is still
+          # required. The waiver has to fail closed: it is the one thing here
+          # that can let a change merge untested.
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          EVENT: ${{ github.event_name }}
         run: |
           if [ "$RESULT" = "success" ]; then
             echo "Integration suite passed on this commit."
             exit 0
           fi
+
           if [ "$RESULT" = "skipped" ]; then
+            # Prose cannot break an integration test, and standing the whole
+            # stack up for eleven minutes to prove that costs more than the
+            # check is worth.
+            #
+            # Nested under skipped on purpose. Checked before it, the waiver
+            # also swallowed a suite that ran and *failed* on a docs-only pull
+            # request, which is a real failure whatever the diff touched. Found
+            # by testing the combinations rather than the happy path.
+            #
+            # Restricted to pull_request because the filter compares against the
+            # pull request's base; on any other event there is nothing to
+            # compare and the answer would be meaningless.
+            if [ "$EVENT" = "pull_request" ] && [ "$CODE_CHANGED" = "false" ]; then
+              echo "No runtime files changed, so the integration suite is not required."
+              echo "Touching anything outside docs and markdown will require it again."
+              exit 0
+            fi
             echo "The integration suite has not run on this commit."
             echo "Comment /run-tests on the pull request to label it and run them."
             exit 1

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -129,14 +129,7 @@ jobs:
         # do. Its own action can.
         uses: lycheeverse/lychee-action@v2
         with:
-          # The same set MegaLinter's SPELL_LYCHEE_FILTER_REGEX_INCLUDE named.
-          # The issue and pull request templates were missing from a first
-          # version of this and are the whole reason to write the old filter
-          # out rather than approximate it.
-          args: >-
-            --no-progress --config lychee.toml
-            README.md LICENSE.md NOTICE.md docs/
-            .github/ISSUE_TEMPLATE/ .github/PULL_REQUEST_TEMPLATE.md
+          args: --no-progress --config lychee.toml README.md LICENSE.md NOTICE.md docs/
           fail: true
 
   prerequisites:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -193,7 +193,12 @@ jobs:
           fetch-depth: 0
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter@v9
+        # The cupcake flavor, not the default image: 2.64 GB against 4.77 GB,
+        # and it carries every linter enabled in .mega-linter.yml. Checked by
+        # listing the binaries inside the image rather than trusting the
+        # descriptors, which claim a linter with no declared flavors belongs to
+        # every flavor and are wrong about it.
+        uses: oxsecurity/megalinter/flavors/cupcake@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # betterleaks' own git invocation runs in a context that doesn't

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -334,6 +334,8 @@ jobs:
       && (needs.prerequisites.result == 'success' || needs.prerequisites.result == 'skipped') }}
     env:
       PROTONVPN_PRIVATE_KEY: ${{ secrets.PROTONVPN_PRIVATE_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: read
       # To take the label back off again, see the last step.
@@ -432,6 +434,26 @@ jobs:
       - name: Generate self-signed certificate
         timeout-minutes: 3
         run: make generate_certificate
+
+      - name: Log in to Docker Hub
+        # 26 of this stack's images come from Docker Hub, and anonymous pulls
+        # are rate limited per source address while GitHub runners share
+        # addresses across every project on the pool. Three runs on this pull
+        # request stalled mid-pull long enough to hit a timeout, each in a
+        # different step, which is the shape throttling makes.
+        #
+        # podman login rather than docker/login-action: podman is the runtime
+        # here and only falls back to ~/.docker/config.json, so this writes the
+        # auth file it actually uses.
+        #
+        # Skipped when the secret is absent, which is every pull request from a
+        # fork, since GitHub does not expose secrets to those. They keep pulling
+        # anonymously and this must not fail them.
+        if: env.DOCKERHUB_USERNAME != ''
+        timeout-minutes: 2
+        run: |
+          printf '%s' "$DOCKERHUB_TOKEN" \
+            | podman login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Pull container images
         # Split out of `make start` so the pull is visible and bounded on its

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -129,7 +129,14 @@ jobs:
         # do. Its own action can.
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --config lychee.toml README.md LICENSE.md NOTICE.md docs/
+          # The same set MegaLinter's SPELL_LYCHEE_FILTER_REGEX_INCLUDE named.
+          # The issue and pull request templates were missing from a first
+          # version of this and are the whole reason to write the old filter
+          # out rather than approximate it.
+          args: >-
+            --no-progress --config lychee.toml
+            README.md LICENSE.md NOTICE.md docs/
+            .github/ISSUE_TEMPLATE/ .github/PULL_REQUEST_TEMPLATE.md
           fail: true
 
   prerequisites:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -115,6 +115,23 @@ jobs:
           # this job drops it and is left checking what only pre-commit checks.
           SKIP: megalinter-incremental
 
+      - name: Lint .env.example
+        # dotenv-linter publishes no pre-commit hook at any released tag
+        # (checked v3.3.0 and v4.0.0), so it runs as its own action now that
+        # MegaLinter's security flavor no longer carries it.
+        uses: dotenv-linter/action-dotenv-linter@v2
+        with:
+          dotenv_linter_flags: .env.example
+
+      - name: Check documentation links
+        # lychee's pre-commit hook is language: system and expects the binary
+        # already on PATH, so it cannot install itself the way the other hooks
+        # do. Its own action can.
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --config lychee.toml README.md LICENSE.md NOTICE.md docs/
+          fail: true
+
   prerequisites:
     name: Prerequisite Checks
     runs-on: ubuntu-latest
@@ -193,7 +210,12 @@ jobs:
           fetch-depth: 0
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter@v9
+        # The security flavor, not the default image: 1.36 GB against 4.77 GB,
+        # and it carries exactly the project-mode scanners that pre-commit
+        # cannot replace. Checked by listing the binaries inside both images
+        # rather than trusting the descriptors, which claim a linter with no
+        # declared flavors is in every flavor and are wrong about it.
+        uses: oxsecurity/megalinter/flavors/security@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # betterleaks' own git invocation runs in a context that doesn't

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -14,15 +14,14 @@ on:
     # restated here rather than inherited.
     types: [opened, synchronize, reopened, labeled, ready_for_review]
   # Lets .github/workflows/comment-dispatch.yml re-run this against a PR's
-  # current head from a `/run-check` or `/run-tests` comment, without
-  # needing a new push. Always dispatched off main (see that workflow), so
+  # current head from a `/run-check` comment, without needing a new push. Always dispatched off main (see that workflow), so
   # this definition is never taken from the PR's own, potentially-modified
   # copy; pr_number only controls which commit gets checked out below.
   # job_scope narrows which jobs actually run for that comment: `/run-check`
-  # wants pr_check (pre-commit) and the MegaLinter job that follows it.
-  # `/run-tests` no longer comes through here at all, it applies a label
-  # instead (see comment-dispatch.yml for why), so the `tests` scope is left
-  # for a manual run from the Actions tab only. A plain manual run (job_scope
+  # wants pr_check (pre-commit) and the MegaLinter job that follows it. There is
+  # no comment for the suite, which is started by the `run-tests` label instead
+  # (see comment-dispatch.yml for why a comment cannot), so the `tests` scope is
+  # left for a manual run from the Actions tab only. A plain manual run (job_scope
   # left as "all") behaves like a normal pull_request-triggered run, except
   # that it also runs the suite, which an unlabelled pull_request does not.
   #checkov:skip=CKV_GHA_7:workflow_dispatch itself requires write access to
@@ -309,10 +308,10 @@ jobs:
     # timing out at 25 minutes before reaching a single test. Nothing in those
     # runs could have been affected by the change.
     #
-    # A code owner applies the label by commenting `/run-tests`, which
-    # comment-dispatch.yml restricts to OWNER, MEMBER and COLLABORATOR: that
-    # restriction is the gate, and labelling is restricted to collaborators by
-    # GitHub anyway. Once labelled, a further push does re-run this, which is
+    # A code owner applies the `run-tests` label directly, which GitHub already
+    # restricts to collaborators, so the permission model needs no check of our
+    # own. A comment cannot do it: a label applied by a workflow's GITHUB_TOKEN
+    # triggers nothing, by design (see comment-dispatch.yml). Once labelled, a further push does re-run this, which is
     # deliberate. A required status check is evaluated against the head commit,
     # so a result from before the last push would not count for the merge even
     # if it were kept.
@@ -322,7 +321,7 @@ jobs:
     #
     # !cancelled() rather than always(): a need being skipped must not skip this
     # too (pr_check and megalinter are both skipped for job_scope: tests, which
-    # is the scope `/run-tests` dispatches), but a cancelled run must not go on
+    # is the scope a manual tests-only dispatch uses), but a cancelled run must
     # to spend twenty minutes standing the stack up. Only an actual failure of
     # one of the lint layers blocks it.
     if: >-
@@ -571,11 +570,11 @@ jobs:
             fi
             if [ "$DRAFT" = "true" ]; then
               echo "::notice::Still a draft, so the integration suite is not required yet."
-              echo "Comment /run-tests before marking this ready for review."
+              echo "Apply the run-tests label before marking this ready for review."
               exit 0
             fi
             echo "The integration suite has not run on this commit."
-            echo "Comment /run-tests on the pull request to label it and run them."
+            echo "Apply the run-tests label to the pull request to run them."
             exit 1
           fi
           echo "The integration suite did not pass on this commit (result: $RESULT)."

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -12,7 +12,7 @@ on:
     #
     # Naming any type replaces the default set, so the three defaults are
     # restated here rather than inherited.
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   # Lets .github/workflows/comment-dispatch.yml re-run this against a PR's
   # current head from a `/run-check` or `/run-tests` comment, without
   # needing a new push. Always dispatched off main (see that workflow), so
@@ -287,7 +287,7 @@ jobs:
         run: npx --yes --package renovate@42.99.0 renovate-config-validator --strict
 
   integration:
-    name: Integration Suite
+    name: Integration Tests
     runs-on: ubuntu-latest
     # make test_ci (the last step below), not the full make test: see its
     # own comment on that step for why. The two tiers it does run took
@@ -516,7 +516,7 @@ jobs:
   # is interpreted. It is red until the suite has actually passed on this
   # commit, and it costs a couple of seconds.
   integration_required:
-    name: Integration Tests
+    name: Tests Verified
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [integration, changes]
@@ -527,6 +527,13 @@ jobs:
       - name: Require the suite to have passed on this commit
         env:
           RESULT: ${{ needs.integration.result }}
+          # A draft cannot be merged, so a passing gate on one grants nothing,
+          # and a red check for "you have not asked for tests yet" reads as a
+          # failure when nothing is broken. Enforcement starts when the pull
+          # request is marked ready, which is why ready_for_review is a trigger:
+          # without it, marking ready fires no event and a draft's green gate
+          # would stand.
+          DRAFT: ${{ github.event.pull_request.draft }}
           # Empty unless the changes job both ran and answered, so a skipped or
           # failed filter reads as "not proven docs-only" and the suite is still
           # required. The waiver has to fail closed: it is the one thing here
@@ -555,6 +562,11 @@ jobs:
             if [ "$EVENT" = "pull_request" ] && [ "$CODE_CHANGED" = "false" ]; then
               echo "No runtime files changed, so the integration suite is not required."
               echo "Touching anything outside docs and markdown will require it again."
+              exit 0
+            fi
+            if [ "$DRAFT" = "true" ]; then
+              echo "::notice::Still a draft, so the integration suite is not required yet."
+              echo "Comment /run-tests before marking this ready for review."
               exit 0
             fi
             echo "The integration suite has not run on this commit."

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -115,23 +115,6 @@ jobs:
           # this job drops it and is left checking what only pre-commit checks.
           SKIP: megalinter-incremental
 
-      - name: Lint .env.example
-        # dotenv-linter publishes no pre-commit hook at any released tag
-        # (checked v3.3.0 and v4.0.0), so it runs as its own action now that
-        # MegaLinter's security flavor no longer carries it.
-        uses: dotenv-linter/action-dotenv-linter@v2
-        with:
-          dotenv_linter_flags: .env.example
-
-      - name: Check documentation links
-        # lychee's pre-commit hook is language: system and expects the binary
-        # already on PATH, so it cannot install itself the way the other hooks
-        # do. Its own action can.
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress --config lychee.toml README.md LICENSE.md NOTICE.md docs/
-          fail: true
-
   prerequisites:
     name: Prerequisite Checks
     runs-on: ubuntu-latest
@@ -210,12 +193,7 @@ jobs:
           fetch-depth: 0
 
       - name: MegaLinter
-        # The security flavor, not the default image: 1.36 GB against 4.77 GB,
-        # and it carries exactly the project-mode scanners that pre-commit
-        # cannot replace. Checked by listing the binaries inside both images
-        # rather than trusting the descriptors, which claim a linter with no
-        # declared flavors is in every flavor and are wrong about it.
-        uses: oxsecurity/megalinter/flavors/security@v9
+        uses: oxsecurity/megalinter@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # betterleaks' own git invocation runs in a context that doesn't

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,17 +1,19 @@
 ---
+# Only what the security flavor ships and pre-commit cannot do. Everything
+# file-shaped moved out: the full image is a 4.77 GB download and the security
+# flavor is 1.36 GB, which is 2m45s of pull turned into well under a minute on
+# every run. What is left is the project-mode scanning that needs the whole
+# working tree, plus the two linters the flavor happens to carry.
+#
+# The rest did not disappear. cspell, editorconfig-checker, markdownlint, ruff,
+# shfmt and check-json already run as pre-commit hooks, so CI still enforces
+# them through Code Check's --all-files sweep; actionlint joins them; lychee and
+# dotenv-linter run as their publishers' own actions, being the two with no
+# usable pre-commit hook.
 ENABLE_LINTERS:
-  - ACTION_ACTIONLINT
   - BASH_EXEC
   - BASH_SHELLCHECK
-  - BASH_SHFMT
-  - EDITORCONFIG_EDITORCONFIG_CHECKER
-  - ENV_DOTENV_LINTER
-  - JSON_JSONLINT
-  - MARKDOWN_MARKDOWNLINT
   - PYTHON_BANDIT
-  - PYTHON_RUFF
-  - SPELL_CSPELL
-  - SPELL_LYCHEE
   - REPOSITORY_BETTERLEAKS
   - REPOSITORY_CHECKOV
   - REPOSITORY_TRIVY
@@ -71,9 +73,6 @@ EXCLUDED_DIRECTORIES:
   - logs
   - storage
 
-SPELL_LYCHEE_FILTER_REGEX_INCLUDE: (^README\.md$|^LICENSE\.md$|^NOTICE\.md$|^docs/.*\.md$|^\.github/(ISSUE_TEMPLATE/.*\.md|PULL_REQUEST_TEMPLATE\.md)$)
-ENV_DOTENV_LINTER_FILTER_REGEX_INCLUDE: (^\.env\.example$)
-JSON_JSONLINT_FILTER_REGEX_INCLUDE: (^\.cspell\.json$|^\.devcontainer/.*\.json$)
 
 # betterleaks is the secret scanner that covers this repo's credential shapes.
 #
@@ -112,14 +111,11 @@ REPOSITORY_TRIVY_ARGUMENTS: "--ignorefile .trivyignore.yaml"
 # patches/ holds vendored upstream source bind-mounted into containers to
 # apply local fixes; it is not code we author, so it should not be linted,
 # reformatted, or spellchecked.
-EDITORCONFIG_EDITORCONFIG_CHECKER_FILTER_REGEX_EXCLUDE: (^patches/)
-BASH_SHFMT_FILTER_REGEX_EXCLUDE: (^patches/)
 
 # configs/*/config/ holds files the applications generate: Qt window state,
 # base64 blobs, provider names. Spellchecking those yields nothing but noise
 # (186 unknown "words" in one run, almost all base64). .gitleaksignore is
 # machine-generated commit fingerprints for the same reason.
-SPELL_CSPELL_FILTER_REGEX_EXCLUDE: (^patches/|^configs/.*/config/|^configs/.*/custom-(cont-init|services)\.d/|^\.gitleaksignore$)
 
 # custom-cont-init.d and custom-services.d hold third-party arr-scripts
 # bootstrap scripts, vendored the same way as patches/ and not ours to fix.
@@ -129,7 +125,6 @@ BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: (^patches/|^configs/.*/custom-(cont-init|s
 # style notes that the commit-time hook deliberately ignores.
 BASH_SHELLCHECK_ARGUMENTS: "--severity=error"
 REPOSITORY_CHECKOV_ARGUMENTS: --skip-framework secrets --skip-path configs
-PYTHON_RUFF_FILTER_REGEX_INCLUDE: (^tests/)
 PYTHON_BANDIT_FILTER_REGEX_INCLUDE: (^tests/)
 PYTHON_BANDIT_FILTER_REGEX_EXCLUDE: (tests/\.venv/)
 PYTHON_BANDIT_ARGUMENTS: "--skip B101,B105,B314,B404,B405,B501,B603,B607"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,4 +1,14 @@
 ---
+# The cupcake flavor carries all of these. It is a 2.64 GB download against the
+# default image's 4.77 GB, and pulling that image was 2m45s of MegaLinter's ~4m
+# job on every run.
+#
+# bandit is the one linter cupcake lacks, so it moved to pre-commit, where it
+# now runs at commit time rather than minutes later in CI. Nothing else changed
+# hands: the smaller security flavor would have saved another 1.28 GB but needed
+# nine linters relocated, and translating one of their filters by hand already
+# dropped two paths silently, which is not a trade worth making for a linter
+# suite whose job is to notice things.
 ENABLE_LINTERS:
   - ACTION_ACTIONLINT
   - BASH_EXEC
@@ -8,7 +18,6 @@ ENABLE_LINTERS:
   - ENV_DOTENV_LINTER
   - JSON_JSONLINT
   - MARKDOWN_MARKDOWNLINT
-  - PYTHON_BANDIT
   - PYTHON_RUFF
   - SPELL_CSPELL
   - SPELL_LYCHEE
@@ -130,6 +139,3 @@ BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: (^patches/|^configs/.*/custom-(cont-init|s
 BASH_SHELLCHECK_ARGUMENTS: "--severity=error"
 REPOSITORY_CHECKOV_ARGUMENTS: --skip-framework secrets --skip-path configs
 PYTHON_RUFF_FILTER_REGEX_INCLUDE: (^tests/)
-PYTHON_BANDIT_FILTER_REGEX_INCLUDE: (^tests/)
-PYTHON_BANDIT_FILTER_REGEX_EXCLUDE: (tests/\.venv/)
-PYTHON_BANDIT_ARGUMENTS: "--skip B101,B105,B314,B404,B405,B501,B603,B607"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,19 +1,17 @@
 ---
-# Only what the security flavor ships and pre-commit cannot do. Everything
-# file-shaped moved out: the full image is a 4.77 GB download and the security
-# flavor is 1.36 GB, which is 2m45s of pull turned into well under a minute on
-# every run. What is left is the project-mode scanning that needs the whole
-# working tree, plus the two linters the flavor happens to carry.
-#
-# The rest did not disappear. cspell, editorconfig-checker, markdownlint, ruff,
-# shfmt and check-json already run as pre-commit hooks, so CI still enforces
-# them through Code Check's --all-files sweep; actionlint joins them; lychee and
-# dotenv-linter run as their publishers' own actions, being the two with no
-# usable pre-commit hook.
 ENABLE_LINTERS:
+  - ACTION_ACTIONLINT
   - BASH_EXEC
   - BASH_SHELLCHECK
+  - BASH_SHFMT
+  - EDITORCONFIG_EDITORCONFIG_CHECKER
+  - ENV_DOTENV_LINTER
+  - JSON_JSONLINT
+  - MARKDOWN_MARKDOWNLINT
   - PYTHON_BANDIT
+  - PYTHON_RUFF
+  - SPELL_CSPELL
+  - SPELL_LYCHEE
   - REPOSITORY_BETTERLEAKS
   - REPOSITORY_CHECKOV
   - REPOSITORY_TRIVY
@@ -73,6 +71,9 @@ EXCLUDED_DIRECTORIES:
   - logs
   - storage
 
+SPELL_LYCHEE_FILTER_REGEX_INCLUDE: (^README\.md$|^LICENSE\.md$|^NOTICE\.md$|^docs/.*\.md$|^\.github/(ISSUE_TEMPLATE/.*\.md|PULL_REQUEST_TEMPLATE\.md)$)
+ENV_DOTENV_LINTER_FILTER_REGEX_INCLUDE: (^\.env\.example$)
+JSON_JSONLINT_FILTER_REGEX_INCLUDE: (^\.cspell\.json$|^\.devcontainer/.*\.json$)
 
 # betterleaks is the secret scanner that covers this repo's credential shapes.
 #
@@ -111,11 +112,14 @@ REPOSITORY_TRIVY_ARGUMENTS: "--ignorefile .trivyignore.yaml"
 # patches/ holds vendored upstream source bind-mounted into containers to
 # apply local fixes; it is not code we author, so it should not be linted,
 # reformatted, or spellchecked.
+EDITORCONFIG_EDITORCONFIG_CHECKER_FILTER_REGEX_EXCLUDE: (^patches/)
+BASH_SHFMT_FILTER_REGEX_EXCLUDE: (^patches/)
 
 # configs/*/config/ holds files the applications generate: Qt window state,
 # base64 blobs, provider names. Spellchecking those yields nothing but noise
 # (186 unknown "words" in one run, almost all base64). .gitleaksignore is
 # machine-generated commit fingerprints for the same reason.
+SPELL_CSPELL_FILTER_REGEX_EXCLUDE: (^patches/|^configs/.*/config/|^configs/.*/custom-(cont-init|services)\.d/|^\.gitleaksignore$)
 
 # custom-cont-init.d and custom-services.d hold third-party arr-scripts
 # bootstrap scripts, vendored the same way as patches/ and not ours to fix.
@@ -125,6 +129,7 @@ BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: (^patches/|^configs/.*/custom-(cont-init|s
 # style notes that the commit-time hook deliberately ignores.
 BASH_SHELLCHECK_ARGUMENTS: "--severity=error"
 REPOSITORY_CHECKOV_ARGUMENTS: --skip-framework secrets --skip-path configs
+PYTHON_RUFF_FILTER_REGEX_INCLUDE: (^tests/)
 PYTHON_BANDIT_FILTER_REGEX_INCLUDE: (^tests/)
 PYTHON_BANDIT_FILTER_REGEX_EXCLUDE: (tests/\.venv/)
 PYTHON_BANDIT_ARGUMENTS: "--skip B101,B105,B314,B404,B405,B501,B603,B607"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,14 +104,6 @@ repos:
       - id: yamllint
         exclude: *app_managed
 
-  - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v10.0.1
-    hooks:
-      - id: cspell
-        # configs/*/config/ is application-generated (Qt state, base64 blobs);
-        # .gitleaksignore is machine-generated commit fingerprints.
-        exclude: '^patches/|^configs/.*/config/|^configs/.*/custom-(cont-init|services)\.d/|^\.gitleaksignore$'
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:
@@ -153,15 +145,26 @@ repos:
         exclude: ^tests/\.venv/
         args: ["--skip", "B101,B105,B314,B404,B405,B501,B603,B607"]
 
+  # Pinned to the same flavor and release CI runs. The standalone cspell hook
+  # used to live above this and was removed: it resolved its own dictionary
+  # packages, so `dockerhub` was present in its copy of @cspell/dict-software-
+  # tools and absent from the image's, and a word could pass every local hook
+  # and still fail CI. Two spellcheckers with different dictionaries are worse
+  # than one, and MegaLinter's is the one that decides the build.
+  #
+  # Without --flavor this pulls the default image, whose cspell is 9.7.0 against
+  # cupcake's 10.0.1, which is the same divergence one level down.
   - repo: https://github.com/oxsecurity/megalinter
     rev: v9.6.0
     hooks:
       - id: megalinter-incremental
         stages: [pre-commit]
         verbose: true
+        args: ["mega-linter-runner", "--flavor", "cupcake", "--release", "v9.6.0"]
       - id: megalinter-full
         stages: [pre-push]
         verbose: true
+        args: ["mega-linter-runner", "--flavor", "cupcake", "--release", "v9.6.0"]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.23.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,17 @@ repos:
         pass_filenames: false
         always_run: true
 
+  # Moved out of MegaLinter with the switch to its cupcake flavor, which is the
+  # one linter that flavor does not carry. Same scope and skip list it had
+  # there: tests/ only, and B101 (assert) because pytest is built on it.
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        files: ^tests/
+        exclude: ^tests/\.venv/
+        args: ["--skip", "B101,B105,B314,B404,B405,B501,B603,B607"]
+
   - repo: https://github.com/oxsecurity/megalinter
     rev: v9.6.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,14 @@ repos:
         pass_filenames: false
         always_run: true
 
+  # Moved out of MegaLinter with the switch to its security flavor, which does
+  # not carry actionlint. Unlike lychee and dotenv-linter it has a real
+  # pre-commit hook, so it runs at commit time here rather than only in CI.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/oxsecurity/megalinter
     rev: v9.6.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,14 +142,6 @@ repos:
         pass_filenames: false
         always_run: true
 
-  # Moved out of MegaLinter with the switch to its security flavor, which does
-  # not carry actionlint. Unlike lychee and dotenv-linter it has a real
-  # pre-commit hook, so it runs at commit time here rather than only in CI.
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
-    hooks:
-      - id: actionlint
-
   - repo: https://github.com/oxsecurity/megalinter
     rev: v9.6.0
     hooks:

--- a/docker-compose-media-library.yml
+++ b/docker-compose-media-library.yml
@@ -72,7 +72,7 @@ secrets:
 services:
   jellyfin:
     <<: *limit-jellyfin
-    image: lscr.io/linuxserver/jellyfin:${JELLYFIN_VERSION}
+    image: docker.io/linuxserver/jellyfin:${JELLYFIN_VERSION}
     container_name: jellyfin
     profiles: ["${JELLYFIN_PROFILE}"]
     networks:
@@ -152,7 +152,7 @@ services:
 
   calibre:
     <<: *limit-calibre
-    image: lscr.io/linuxserver/calibre:${CALIBRE_VERSION}
+    image: docker.io/linuxserver/calibre:${CALIBRE_VERSION}
     container_name: calibre
     profiles: ["${CALIBRE_PROFILE}"]
     networks:
@@ -201,7 +201,7 @@ services:
 
   calibre-web:
     <<: *limit-calibreweb
-    image: lscr.io/linuxserver/calibre-web:${CALIBREWEB_VERSION}
+    image: docker.io/linuxserver/calibre-web:${CALIBREWEB_VERSION}
     container_name: calibre-web
     profiles: ["${CALIBREWEB_PROFILE}"]
     networks:

--- a/docker-compose-nzb.yml
+++ b/docker-compose-nzb.yml
@@ -42,7 +42,7 @@ secrets:
 services:
   sabnzbd:
     <<: *limit-downloaders
-    image: lscr.io/linuxserver/sabnzbd:${SABNZBD_VERSION}
+    image: docker.io/linuxserver/sabnzbd:${SABNZBD_VERSION}
     container_name: sabnzbd
     depends_on:
       ${VPN_PROVIDER}:
@@ -84,7 +84,7 @@ services:
   # Legacy Usenet client retained for existing setups. New installs use SABnzbd.
   nzbget:
     <<: *limit-downloaders
-    image: lscr.io/linuxserver/nzbget:${NZBGET_VERSION}
+    image: docker.io/linuxserver/nzbget:${NZBGET_VERSION}
     container_name: nzbget
     depends_on: ["${VPN_PROVIDER}"]
     profiles: ["${NZBGET_PROFILE}"]
@@ -114,7 +114,7 @@ services:
       - ${USENET_FOLDER}:/data/usenet${DATA_VOLUME_FLAGS}
   nzbhydra2:
     <<: *limit-nzbhydra2
-    image: lscr.io/linuxserver/nzbhydra2:${NZBHYDRA2_VERSION}
+    image: docker.io/linuxserver/nzbhydra2:${NZBHYDRA2_VERSION}
     container_name: nzbhydra2
     profiles: ["${NZBHYDRA2_PROFILE}"]
     networks:

--- a/docker-compose-observability.yml
+++ b/docker-compose-observability.yml
@@ -126,11 +126,6 @@ services:
       test: wget -q -O /dev/null http://127.0.0.1:9889/metrics || exit 1
   node_exporter:
     <<: *limit-telemetry
-    # Stays on Docker Hub, unlike prometheus above. quay.io publishes this image
-    # too, but at a different digest for the same tag: v1.11.1 is sha256:e9cff4fc
-    # on Docker Hub and sha256:0f422f62 on quay.io. They are not the same
-    # artifact, so swapping the registry would change what runs here rather than
-    # only where it is fetched from.
     image: docker.io/prom/node-exporter:${NODE_EXPORTER_VERSION}
     container_name: node_exporter
     profiles: ["${NODE_EXPORTER_PROFILE}"]
@@ -215,7 +210,7 @@ services:
       - ./scripts/rotate-nginx-logs.sh:/scripts/rotate-nginx-logs.sh:ro,z
   prometheus:
     <<: *limit-telemetry
-    image: quay.io/prometheus/prometheus:${PROMETHEUS_VERSION}
+    image: docker.io/prom/prometheus:${PROMETHEUS_VERSION}
     container_name: prometheus
     profiles: ["${PROMETHEUS_PROFILE}"]
     networks: ["observability"]

--- a/docker-compose-servarr.yml
+++ b/docker-compose-servarr.yml
@@ -73,7 +73,7 @@ secrets:
 services:
   bazarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/bazarr:${BAZARR_VERSION}
+    image: docker.io/linuxserver/bazarr:${BAZARR_VERSION}
     container_name: bazarr
     profiles: ["${BAZARR_PROFILE}"]
     networks:
@@ -96,7 +96,7 @@ services:
 
   lidarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/lidarr:${LIDARR_VERSION}
+    image: docker.io/linuxserver/lidarr:${LIDARR_VERSION}
     container_name: lidarr
     profiles: ["${LIDARR_PROFILE}"]
     networks:
@@ -126,7 +126,7 @@ services:
 
   prowlarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/prowlarr:${PROWLARR_VERSION}
+    image: docker.io/linuxserver/prowlarr:${PROWLARR_VERSION}
     container_name: prowlarr
     profiles: ["${PROWLARR_PROFILE}"]
     networks:
@@ -152,7 +152,7 @@ services:
 
   radarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/radarr:${RADARR_VERSION}
+    image: docker.io/linuxserver/radarr:${RADARR_VERSION}
     container_name: radarr
     profiles: ["${RADARR_PROFILE}"]
     networks:
@@ -180,7 +180,7 @@ services:
 
   readarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/readarr:${READARR_VERSION}
+    image: docker.io/linuxserver/readarr:${READARR_VERSION}
     container_name: readarr
     profiles: ["${READARR_PROFILE}"]
     networks:
@@ -231,7 +231,7 @@ services:
 
   sonarr:
     <<: [*servarr-common, *limit-servarr]
-    image: lscr.io/linuxserver/sonarr:${SONARR_VERSION}
+    image: docker.io/linuxserver/sonarr:${SONARR_VERSION}
     container_name: sonarr
     profiles: ["${SONARR_PROFILE}"]
     networks:

--- a/docker-compose-torrent.yml
+++ b/docker-compose-torrent.yml
@@ -40,7 +40,7 @@ secrets:
 services:
   qbittorrent:
     <<: *limit-downloaders
-    image: lscr.io/linuxserver/qbittorrent:${QBITTORRENT_VERSION}
+    image: docker.io/linuxserver/qbittorrent:${QBITTORRENT_VERSION}
     container_name: qbittorrent
     depends_on:
       ${VPN_PROVIDER}:

--- a/docker-compose-vpn.yml
+++ b/docker-compose-vpn.yml
@@ -89,7 +89,7 @@ services:
   # unmodified against it. Disabled by default; only scripts/seed-vpn-mock.sh
   # ever populates gluetun's config to actually point at it.
   vpn_mock:
-    image: lscr.io/linuxserver/wireguard:${VPN_MOCK_VERSION}
+    image: docker.io/linuxserver/wireguard:${VPN_MOCK_VERSION}
     container_name: vpn_mock
     profiles: ["${VPN_MOCK_PROFILE}"]
     networks:

--- a/docs/COMPOSE_CONVENTIONS.md
+++ b/docs/COMPOSE_CONVENTIONS.md
@@ -63,7 +63,7 @@ Reasoning for the less obvious placements:
 ```yaml
 sonarr:
   <<: [*servarr-common, *limit-servarr]
-  image: lscr.io/linuxserver/sonarr:${SONARR_VERSION}
+  image: docker.io/linuxserver/sonarr:${SONARR_VERSION}
   container_name: sonarr
   profiles: ["${SONARR_PROFILE}"]
   networks:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,10 +105,11 @@ review has settled.
    marker/tier breakdown and how to add a test, and
    [docs/MAKE_COMMANDS.md](MAKE_COMMANDS.md) for the full list of test
    targets. Pull requests do not run the suite on their own: a maintainer asks
-   for it by commenting `/run-tests`, which dispatches the `integration` job in
-   `pull-request-validation.yml`. `/run-check` re-runs the lint layers the same
-   way (see `.github/workflows/comment-dispatch.yml`). Still test manually for
-   anything the suite doesn't cover.
+   for it by commenting `/run-tests`, which applies the `run-tests` label and
+   starts the `Integration Suite` job in `pull-request-validation.yml`.
+   `/run-check` re-runs the lint layers the same way (see
+   `.github/workflows/comment-dispatch.yml`). Still test manually for anything
+   the suite doesn't cover.
 11. Update the documentation accordingly
 12. Issue the pull request!
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Checks run in this order on purpose, so a cheap failure is never paid for
 twice and the expensive one is spent only on the version being merged. The
 integration suite stands the whole stack up and takes upward of twelve
 minutes; it never runs on an unlabelled push. Only repository collaborators
-can ask for it, and the required `Integration Tests` check stays red until it
+can ask for it, and the required `Tests Verified` check stays red until it
 has passed on the current head commit, so nothing merges untested.
 
 If you are contributing from a fork, you cannot apply the label yourself. Say
@@ -78,9 +78,9 @@ review has settled.
       version you intend to merge. Pushing again after labelling re-runs them,
       because a required check only counts against the current head commit.
 
-   The required `Integration Tests` check stays red until the suite has passed
+   The required `Tests Verified` check stays red until the suite has passed
    on the current head commit, so a pull request cannot be merged without it.
-   It is a separate few-second job from the suite (`Integration Suite`), which
+   It is a separate few-second job from the suite (`Integration Tests`), which
    is what makes that true: a job skipped by its own condition is reported to
    branch protection as successful, so gating the suite alone would have made
    an unlabelled pull request mergeable with no tests at all.
@@ -106,7 +106,7 @@ review has settled.
    [docs/MAKE_COMMANDS.md](MAKE_COMMANDS.md) for the full list of test
    targets. Pull requests do not run the suite on their own: a maintainer asks
    for it by commenting `/run-tests`, which applies the `run-tests` label and
-   starts the `Integration Suite` job in `pull-request-validation.yml`.
+   starts the `Integration Tests` job in `pull-request-validation.yml`.
    `/run-check` re-runs the lint layers the same way (see
    `.github/workflows/comment-dispatch.yml`). Still test manually for anything
    the suite doesn't cover.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,19 +27,18 @@ welcome your pull requests.
 | --- | --- | --- |
 | Open as a **draft** | `Code Check` (pre-commit), then `MegaLinter` if it passes | Fix whatever they report |
 | **Mark ready for review** | CodeRabbit reviews (it skips drafts) | Address its comments, pushing fixes |
-| Comment **`/run-tests`** | The integration suite, against your PR | Wait for it to go green |
+| Apply the **`run-tests`** label | The integration suite, against your PR | Wait for it to go green |
 | Merge | | |
 
 Checks run in this order on purpose, so a cheap failure is never paid for
 twice and the expensive one is spent only on the version being merged. The
 integration suite stands the whole stack up and takes upward of twelve
 minutes; it never runs on an unlabelled push. Only repository collaborators
-can ask for it, and the required `Tests Verified` check stays red until it
+can apply it, and the required `Tests Verified` check stays red until it
 has passed on the current head commit, so nothing merges untested.
 
-If you are contributing from a fork, you cannot apply the label yourself. Say
-so in the pull request and a maintainer will run the suite for you once the
-review has settled.
+If you are contributing from a fork you cannot apply the label yourself. Say so
+in the pull request and a maintainer will apply it once the review has settled.
 
 ### The detail
 
@@ -74,8 +73,9 @@ review has settled.
       re-reviewing after every formatting fix.
    3. **Address the review, pushing fixes as needed.** Each push re-runs the
       two lint layers, and CodeRabbit re-reviews.
-   4. **Comment `/run-tests` once the review is settled.** That applies the
-      `run-tests` label, which is what actually starts the integration tests;
+   4. **Apply the `run-tests` label once the review is settled.** From the
+      sidebar, or `gh pr edit <n> --add-label run-tests`. The label is what
+      starts the integration tests;
       they never run on an unlabelled push. They stand the whole stack up and
       take upward of twelve minutes, so they are worth spending once, on the
       version you intend to merge. Pushing again after labelling re-runs them,
@@ -88,8 +88,10 @@ review has settled.
    branch protection as successful, so gating the suite alone would have made
    an unlabelled pull request mergeable with no tests at all.
 
-   `/run-check` re-runs the two lint layers the same way. Both comments are
-   restricted to repository collaborators.
+   `/run-check` re-runs the two lint layers from a comment. There is no
+   equivalent comment for the suite: a label applied by a workflow's own token
+   triggers nothing, by GitHub's design, so the label has to come from a person.
+   Only collaborators can label or use `/run-check`.
 8. Dependabot opens weekly pull requests for `.pre-commit-config.yaml` hook revs
    and GitHub Action version bumps. Eligible patch and minor updates are
    approved and marked for auto-merge once the required checks pass.
@@ -107,12 +109,11 @@ review has settled.
    rewrites every credential). See [docs/TESTING.md](TESTING.md) for the
    marker/tier breakdown and how to add a test, and
    [docs/MAKE_COMMANDS.md](MAKE_COMMANDS.md) for the full list of test
-   targets. Pull requests do not run the suite on their own: a maintainer asks
-   for it by commenting `/run-tests`, which applies the `run-tests` label and
-   starts the `Integration Tests` job in `pull-request-validation.yml`.
-   `/run-check` re-runs the lint layers the same way (see
-   `.github/workflows/comment-dispatch.yml`). Still test manually for anything
-   the suite doesn't cover.
+   targets. Pull requests do not run the suite on their own: a maintainer applies
+   the `run-tests` label, which starts the `Integration Tests` job in
+   `pull-request-validation.yml`. `/run-check` re-runs the lint layers from a
+   comment (see `.github/workflows/comment-dispatch.yml`). Still test manually
+   for anything the suite doesn't cover.
 11. Update the documentation accordingly
 12. Issue the pull request!
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,7 +52,10 @@ review has settled.
    still reporting success, so nothing tells you they were missing until CI
    fails on something the hooks catch locally.
 4. MegaLinter runs incrementally at `pre-commit` and as a broader gate at
-   `pre-push`, while the focused hooks still run directly in `pre-commit`.
+   `pre-push`, while the focused hooks still run directly in `pre-commit`. CI
+   uses its `cupcake` flavor, a 2.64 GB download rather than the default
+   image's 4.77 GB, which carries every linter this repository enables. The one
+   it does not carry, bandit, is a pre-commit hook instead.
    `pre-push` also sweeps the fast hooks across every file, which is the scope
    CI uses. Without that sweep a violation in a file your branch never touched
    passes locally and fails in CI, which is what a linter version bump

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,8 +78,12 @@ in the pull request and a maintainer will apply it once the review has settled.
       starts the integration tests;
       they never run on an unlabelled push. They stand the whole stack up and
       take upward of twelve minutes, so they are worth spending once, on the
-      version you intend to merge. Pushing again after labelling re-runs them,
-      because a required check only counts against the current head commit.
+      version you intend to merge.
+
+      The label is single-use: the suite takes it back off when it finishes, so
+      it always means "run once, now". Push again and the required check goes
+      red, because it only counts against the current head commit; apply the
+      label again when you are ready to spend another run.
 
    The required `Tests Verified` check stays red until the suite has passed
    on the current head commit, so a pull request cannot be merged without it.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,12 +52,7 @@ review has settled.
    still reporting success, so nothing tells you they were missing until CI
    fails on something the hooks catch locally.
 4. MegaLinter runs incrementally at `pre-commit` and as a broader gate at
-   `pre-push`, while the focused hooks still run directly in `pre-commit`. It
-   uses the `security` flavor, which carries only the scanners that need the
-   whole working tree (betterleaks, checkov, trivy, bandit, shellcheck,
-   yamllint). Everything file-shaped is a pre-commit hook instead, so it runs
-   at commit time rather than minutes later in CI, and the image is a 1.36 GB
-   download rather than 4.77 GB.
+   `pre-push`, while the focused hooks still run directly in `pre-commit`.
    `pre-push` also sweeps the fast hooks across every file, which is the scope
    CI uses. Without that sweep a violation in a file your branch never touched
    passes locally and fails in CI, which is what a linter version bump

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,7 +52,12 @@ review has settled.
    still reporting success, so nothing tells you they were missing until CI
    fails on something the hooks catch locally.
 4. MegaLinter runs incrementally at `pre-commit` and as a broader gate at
-   `pre-push`, while the focused hooks still run directly in `pre-commit`.
+   `pre-push`, while the focused hooks still run directly in `pre-commit`. It
+   uses the `security` flavor, which carries only the scanners that need the
+   whole working tree (betterleaks, checkov, trivy, bandit, shellcheck,
+   yamllint). Everything file-shaped is a pre-commit hook instead, so it runs
+   at commit time rather than minutes later in CI, and the image is a 1.36 GB
+   download rather than 4.77 GB.
    `pre-push` also sweeps the fast hooks across every file, which is the scope
    CI uses. Without that sweep a violation in a file your branch never touched
    passes locally and fails in CI, which is what a linter version bump

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -44,7 +44,12 @@ request's own head: the tests would run, pass, and leave the pull request
 blocked regardless.
 
 Until the label goes on, the required `Integration Tests` check is **red**, and
-the pull request cannot be merged. That check is a separate few-second job from
+the pull request cannot be merged. The one exception is a pull request that
+changes nothing but prose: if the `code` paths filter reports no runtime files
+touched, the gate waives the suite, since prose cannot break an integration
+test and an eleven minute stack run to prove it costs more than the check is
+worth. The waiver applies only when the suite never ran. A suite that ran and
+failed is a failure whatever the diff touched. That check is a separate few-second job from
 the suite itself (`Integration Suite`), and it exists for one reason: a job
 skipped by its own `if` is reported to branch protection as successful, so
 gating the suite on a label would otherwise have made an unlabelled pull

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,14 +43,14 @@ head commit, while a required status check is evaluated against the pull
 request's own head: the tests would run, pass, and leave the pull request
 blocked regardless.
 
-Until the label goes on, the required `Integration Tests` check is **red**, and
+Until the label goes on, the required `Tests Verified` check is **red**, and
 the pull request cannot be merged. The one exception is a pull request that
 changes nothing but prose: if the `code` paths filter reports no runtime files
 touched, the gate waives the suite, since prose cannot break an integration
 test and an eleven minute stack run to prove it costs more than the check is
 worth. The waiver applies only when the suite never ran. A suite that ran and
 failed is a failure whatever the diff touched. That check is a separate few-second job from
-the suite itself (`Integration Suite`), and it exists for one reason: a job
+the suite itself (`Integration Tests`), and it exists for one reason: a job
 skipped by its own `if` is reported to branch protection as successful, so
 gating the suite on a label would otherwise have made an unlabelled pull
 request *more* mergeable, not less. The gate is never skipped, so the answer

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,9 +33,10 @@ own integration job actually runs; it is not a substitute for `make test`
 or `make bootstrap_tests` and should not be reached for outside CI.
 
 That integration job does not run on an unlabelled push. It stands the whole
-stack up and takes upward of twelve minutes, so a code owner asks for it by
-commenting `/run-tests` on the pull request once the change has settled, which
-applies the `run-tests` label and starts the job.
+stack up and takes upward of twelve minutes, so a code owner applies the
+`run-tests` label once the change has settled, which starts the job. There is
+no comment shortcut: a label applied by a workflow's own GITHUB_TOKEN triggers
+nothing, because GitHub suppresses runs from events its own token creates.
 
 The label, rather than a `workflow_dispatch`, is what makes the result count.
 A dispatched run is dispatched off `main`, so its check attaches to `main`'s

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -38,6 +38,11 @@ stack up and takes upward of twelve minutes, so a code owner applies the
 no comment shortcut: a label applied by a workflow's own GITHUB_TOKEN triggers
 nothing, because GitHub suppresses runs from events its own token creates.
 
+The label is consumed by the run that it starts. Left in place it would sit on
+the pull request and start another twelve minute run on anything that fires the
+workflow again, reopening a closed pull request included, since the label
+belongs to the pull request rather than the branch.
+
 The label, rather than a `workflow_dispatch`, is what makes the result count.
 A dispatched run is dispatched off `main`, so its check attaches to `main`'s
 head commit, while a required status check is evaluated against the pull

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -525,7 +525,7 @@ ensure_calibre_web_users() {
   local scratch
   scratch=$(mktemp -d)
   podman run --rm -v "${scratch}:/scratch:z" --entrypoint python3 \
-    "lscr.io/linuxserver/calibre-web:${CALIBREWEB_VERSION}" -c "
+    "docker.io/linuxserver/calibre-web:${CALIBREWEB_VERSION}" -c "
 import sys
 sys.path.insert(0, '/app/calibre-web')
 from cps import ub


### PR DESCRIPTION
## Why

Making the suite manual left the required gate demanding an eleven minute stack run from **every** pull request, including ones touching nothing but markdown. The `code` paths filter used to prevent exactly that, and I removed it as dead config in #40 when the suite stopped running automatically. It is not dead once the gate can read it.

That was a side effect of my change rather than a decision, which is why it comes back as its own pull request.

## What

The gate waives the suite when the filter reports no runtime files changed. It fails closed everywhere else:

| `Integration Suite` | `code` filter | Event | Gate |
| --- | --- | --- | --- |
| success | either | any | green |
| skipped | `false` | `pull_request` | **green (waiver)** |
| skipped | `true` | `pull_request` | red |
| skipped | empty / no answer | `pull_request` | red |
| skipped | `false` | `workflow_dispatch` | red |
| failure or cancelled | either | any | red |

Restricted to `pull_request` because the filter compares against the pull request's base; on any other event there is nothing to compare and the answer would be meaningless.

## The bug this nearly shipped with

Written the obvious way, with the waiver checked before the result, it also swallowed a suite that had **run and failed** on a docs-only pull request. That is a real failure whatever the diff touched, and it would have been a gate that quietly stopped gating.

It came out of testing all eleven combinations of suite result, filter answer and event, not from reading the script back. The waiver now sits inside the `skipped` branch, and all eleven behave correctly.

## Also

One sentence in `docs/CONTRIBUTING.md` still said `/run-tests` "dispatches the integration job". It applies a label, as the same document already says correctly in two other places.

## Note on this pull request

It touches workflow files, so the filter reports code changed and the suite **is** required here. The waiver cannot be exercised by the change that introduces it, which is the right way round.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * Improved pull-request validation for drafts, ready-for-review changes, documentation-only updates, and runtime changes.
  * Renamed validation statuses to distinguish **Integration Tests** from **Tests Verified**.
  * Updated linting and security checks for more targeted coverage.
  * Replaced comment-based test requests with authorized, single-use label-based execution.

* **Documentation**
  * Clarified validation requirements, test behavior, linting coverage, fork handling, and manual test procedures.

* **Maintenance**
  * Updated container image references to use Docker Hub while preserving existing versions and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->