### PR TITLE
Validate the comment triggered suite (do not merge)

### DIFF
--- a/scripts/ci-validation-probe.txt
+++ b/scripts/ci-validation-probe.txt
@@ -1,0 +1,5 @@
+Temporary file for validating the comment triggered integration suite.
+
+It exists only so this pull request counts as a code change rather than a prose
+one, which is what stops the docs only waiver from publishing a passing status
+before the suite has run. Delete along with the branch.


### PR DESCRIPTION
## Do not merge

A throwaway pull request that exists to exercise the comment triggered suite now that #42 is on `main`, then to be closed.

What a `/run-tests` comment here should demonstrate:

- the `gate` job authorizes the commenter against the list on `main`, and reacts to the comment only once it has
- the head SHA is resolved from the API, and `Tests Verified` is published as `pending` against it
- the `suite` job checks out the merge ref and proves its second parent is that same head before spending anything
- `is_fork` reads false, so the Docker Hub credentials are passed and the run is treated as trusted
- the `publish` job writes the terminal status against the head SHA, whatever the suite did

The suite itself is expected to fail in `Start stack`, which is the podman hang tracked in #44 and has nothing to do with the gate. A failing suite still validates the machinery here: the point is that the status lands, on the right commit, from the right job.
