### PR TITLE
Stop an unrelated comment cancelling a suite in flight

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,16 @@ permissions:
 # One suite per pull request. A second `/run-tests` supersedes the first rather
 # than standing a competing stack up on the same runner pool.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  # Keyed on the pull request only for the comments that actually start a suite.
+  # Every other comment fires this workflow too, and those runs skip every job,
+  # but they still joined the group and cancelled whatever was in flight:
+  # confirmed live, CodeRabbit's review summary landed fourteen seconds after a
+  # `/run-tests` and cancelled the run that comment had just started. Runs that
+  # will not do anything get their own group, so they cancel nothing.
+  group: >-
+    ${{ github.workflow }}-${{
+    startsWith(github.event.comment.body, '/run-tests')
+    && github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -440,11 +440,20 @@ jobs:
   publish:
     name: Publish the result
     needs: [gate, suite]
-    # always(), so a failed or cancelled suite reports a red status rather than
-    # leaving the pull request waiting on a context that never arrives. Skipped
-    # when the suite never ran, because there is then no result to report and
-    # the pending status was never written either.
-    if: always() && needs.suite.result != 'skipped'
+    # always(), so a failed suite reports a red status rather than leaving the
+    # pull request waiting on a context that never arrives.
+    #
+    # Not on a skip, because the suite never ran and no pending status was
+    # written either. Not on a cancellation, because there are only two ways to
+    # get one and neither wants a status from here. A second `/run-tests`
+    # supersedes the first, and the superseded run publishing `failure` would
+    # overwrite the pending status the newer one has already written, or worse,
+    # land after that run's own result and bury it. A person cancelling by hand
+    # leaves the pending status standing, which reads as waiting and blocks the
+    # merge, which is the honest answer: nothing was proven about this commit.
+    if: >-
+      always() && needs.suite.result != 'skipped'
+      && needs.suite.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -455,9 +464,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUITE_RESULT: ${{ needs.suite.result }}
         run: |
+          # No cancelled branch: the job condition above excludes it, so a
+          # superseded run never writes over a newer one's status.
           case "$SUITE_RESULT" in
             success) state=success; desc="Integration suite passed on this commit" ;;
-            cancelled) state=failure; desc="Integration suite was cancelled" ;;
             *) state=failure; desc="Integration suite failed" ;;
           esac
           gh api --method POST \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,20 +42,8 @@ on:
 permissions:
   contents: read
 
-# One suite per pull request. A second `/run-tests` supersedes the first rather
-# than standing a competing stack up on the same runner pool.
-concurrency:
-  # Keyed on the pull request only for the comments that actually start a suite.
-  # Every other comment fires this workflow too, and those runs skip every job,
-  # but they still joined the group and cancelled whatever was in flight:
-  # confirmed live, CodeRabbit's review summary landed fourteen seconds after a
-  # `/run-tests` and cancelled the run that comment had just started. Runs that
-  # will not do anything get their own group, so they cancel nothing.
-  group: >-
-    ${{ github.workflow }}-${{
-    startsWith(github.event.comment.body, '/run-tests')
-    && github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
+# The concurrency group lives on the `suite` job rather than here, because at
+# this level it cannot tell who is asking. See that job for the reasoning.
 
 env:
   # The context name branch protection requires. Changing it means changing the
@@ -165,6 +153,27 @@ jobs:
     if: needs.gate.outputs.authorized == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # One suite per pull request: a second `/run-tests` supersedes the first
+    # rather than standing a competing stack up on the same runner pool.
+    #
+    # On the job and not the workflow, which is what makes it safe. A
+    # workflow-level group is joined before any job runs, so it cannot depend on
+    # who commented, and every comment on a pull request fires this workflow.
+    # That cost a suite already: CodeRabbit's review summary landed fourteen
+    # seconds after a `/run-tests` and cancelled the run that comment had just
+    # started. Keying the group on the comment body alone would have fixed that
+    # one case and left a worse one, since anybody at all can type `/run-tests`
+    # and would then have been able to cancel a maintainer's run, the gate
+    # rejecting them afterwards being no help to the twelve minutes already
+    # thrown away.
+    #
+    # Here the group is only ever joined by a job that has already passed the
+    # gate, so an unauthorized comment skips this job and cancels nothing, and
+    # the allowlist stays in one place instead of being restated in an
+    # expression that cannot read it.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
     # This job runs the pull request's own code, so it gets a token that can do
     # nothing but read this public repository, and no `statuses: write`. Steps
     # below reference a secret only where the head branch is in this repository.


### PR DESCRIPTION
## Why

Found on the first real use of the comment triggered suite, in #45.

`/run-tests` was posted at 20:03:10 and the gate started a run. CodeRabbit's review summary landed at 20:03:24, fourteen seconds later. That comment is an `issue_comment` event too, so it started a second run of this workflow, which skipped every job, as intended. What was not intended is that it joined the same concurrency group first and cancelled the suite.

The pull request was left with `Tests Verified` red, reading "Integration suite was cancelled", for a run nobody cancelled.

## What

The group keys on the pull request number only for comments that actually ask for a run. Anything else gets a group of its own, so it cancels nothing. A second `/run-tests` still supersedes the first, which is the behaviour the group exists for.

```yaml
group: >-
  ${{ github.workflow }}-${{
  startsWith(github.event.comment.body, '/run-tests')
  && github.event.issue.number || github.run_id }}
```

## Note on testing this

Same constraint as #42: an `issue_comment` workflow only ever runs the default branch's copy of itself, so this cannot be exercised from its own branch. #45 is still open and will demonstrate it once this is on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test run coordination so authorized `/run-tests` requests cancel previous runs for the same pull request.
  * Prevented unrelated or unauthorized comment-triggered requests from canceling active test runs.
  * Prevented canceled test runs from being reported as failures, preserving pending or newer results.
  * Reduced duplicate or conflicting test activity, helping ensure the latest authorized test request receives priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->