### PR TITLE
Show the fork count beside the stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub issues](https://img.shields.io/github/issues-raw/ivan-pinatti/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/ivan-pinatti?logo=Github&style=for-the-badge)
 ![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
+![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
 
 The code on this repository is intended to be used to share media content with
 various networks such as Torrent and Usenet while protecting your privacy


### PR DESCRIPTION
## What

Adds the repository's fork count to the badge row at the top of the README, immediately after the star count.

```markdown
![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
```

Same shields endpoint family, same `style=for-the-badge`, same `logo=Github` as the three badges beside it, so the row stays one row rather than looking like something bolted on.

## Note

Prose only, so the `code` paths filter reports no runtime files touched and the docs-only waiver answers for `Tests Verified` rather than spending a twelve minute stack run to prove a badge cannot break a container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a GitHub forks badge to the README header for improved project visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->