### PR TITLE
Record why megalinter-reports is still excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,14 @@ CLAUDE.md
 *.swo
 *~
 node_modules/
+# Nothing writes this any more: MegaLinter was replaced by pre-commit hooks in
+# PR #50 and its config is gone. The entry stays deliberately, because a clone
+# that predates that change still has the directory sitting on disk, and it is
+# the kind of generated output that gets swept into a `git add -A` without
+# anyone noticing. Keeping one line here is cheaper than a commit that has to be
+# undone. The same reasoning keeps it out of backups (see the Makefile's
+# COMMON_BACKUP_EXCLUDES) and away from trivy (see .pre-commit-config.yaml).
+# Remove all four once no working copy is old enough to have the directory.
 megalinter-reports/
 
 # dotenv ###

--- a/.gitignore
+++ b/.gitignore
@@ -29,12 +29,17 @@ CLAUDE.md
 node_modules/
 # Nothing writes this any more: MegaLinter was replaced by pre-commit hooks in
 # PR #50 and its config is gone. The entry stays deliberately, because a clone
-# that predates that change still has the directory sitting on disk, and it is
-# the kind of generated output that gets swept into a `git add -A` without
-# anyone noticing. Keeping one line here is cheaper than a commit that has to be
-# undone. The same reasoning keeps it out of backups (see the Makefile's
-# COMMON_BACKUP_EXCLUDES) and away from trivy (see .pre-commit-config.yaml).
-# Remove all four once no working copy is old enough to have the directory.
+# that predates that change still has the directory on disk, and it is the kind
+# of generated output that gets swept into a `git add -A` without anyone
+# noticing. One line here is cheaper than a commit that has to be undone.
+#
+# Two places guard against that stale directory, and only two, because they are
+# the two that look at the filesystem rather than at what git tracks: this file,
+# and trivy's --skip-dirs in .pre-commit-config.yaml, which scans from the
+# repository root. The backup needs no such entry, and had one until PR #51:
+# every tar archives `.env certs configs` by name, so a top-level directory is
+# never a candidate and excluding it did nothing. Remove both once no working
+# copy is old enough to still have the directory.
 megalinter-reports/
 
 # dotenv ###

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,18 @@ RESTORE_SAFETY_ARCHIVE := $(BACKUP_DIR)/pre-restore-$(BACKUP_TIMESTAMP).tar.gz
 # from every backup this repo has ever taken, which was discovered the worst
 # possible way, when a restore could not put them back. `cache` and `logs`
 # below are unanchored on purpose: dropping those at any depth is intended.
+#
+# `megalinter-reports` is kept although nothing writes it since MegaLinter was
+# replaced by pre-commit hooks in PR #50. tar walks the filesystem rather than
+# asking git, which is why `cache`, `logs` and `node_modules` are all listed
+# despite being gitignored, and a stale megalinter-reports/ left behind in an
+# older clone would land in the backup for exactly the same reason. The
+# .gitignore entry survives on the same grounds, and tests/test_backup.py
+# asserts this one, so the three move together or not at all.
+#
+# Note the comments have to live here rather than beside the flag they describe:
+# every line below is one backslash-continued logical line, so a `#` among them
+# would comment out every remaining exclude and silently shrink this list.
 COMMON_BACKUP_EXCLUDES := \
 	--exclude=.git \
 	--exclude=.codex \

--- a/Makefile
+++ b/Makefile
@@ -97,17 +97,13 @@ RESTORE_SAFETY_ARCHIVE := $(BACKUP_DIR)/pre-restore-$(BACKUP_TIMESTAMP).tar.gz
 # possible way, when a restore could not put them back. `cache` and `logs`
 # below are unanchored on purpose: dropping those at any depth is intended.
 #
-# `megalinter-reports` is kept although nothing writes it since MegaLinter was
-# replaced by pre-commit hooks in PR #50. tar walks the filesystem rather than
-# asking git, which is why `cache`, `logs` and `node_modules` are all listed
-# despite being gitignored, and a stale megalinter-reports/ left behind in an
-# older clone would land in the backup for exactly the same reason. The
-# .gitignore entry survives on the same grounds, and tests/test_backup.py
-# asserts this one, so the three move together or not at all.
+# Comments have to live here rather than beside the flag they describe: the
+# list below is one backslash-continued logical line, so a `#` among the flags
+# would comment out every exclude after it and silently shrink this list.
 #
-# Note the comments have to live here rather than beside the flag they describe:
-# every line below is one backslash-continued logical line, so a `#` among them
-# would comment out every remaining exclude and silently shrink this list.
+# By the same token, a name here only earns its place if it can appear *under*
+# `.env`, `certs` or `configs`. An exclude for a top-level directory does
+# nothing, because a top-level directory is never handed to tar to begin with.
 COMMON_BACKUP_EXCLUDES := \
 	--exclude=.git \
 	--exclude=.codex \
@@ -118,7 +114,6 @@ COMMON_BACKUP_EXCLUDES := \
 	--exclude='*.pid' \
 	--exclude=cache \
 	--exclude=logs \
-	--exclude=megalinter-reports \
 	--exclude=node_modules \
 	--exclude=storage \
 	--exclude=tests \

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -143,7 +143,9 @@ Neither backup mode includes media/download libraries or repository-only state:
 
 - `.git/`
 - `tests/`
-- `megalinter-reports/`
+- `megalinter-reports/` (nothing writes this since MegaLinter was replaced by
+  pre-commit hooks; the exclusion is kept because `tar` walks the filesystem,
+  so a stale copy in an older clone would otherwise be archived)
 - `data/` (includes `data/media/`, the actual media library)
 - `storage/`
 - `cache/`

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -81,8 +81,7 @@ Jellyfin's metadata library. Caches are **not** among them: `--exclude=cache`
 is unanchored and applies to both modes, so any directory named `cache` is
 dropped wherever it appears. That is deliberate, since the largest of them
 hold regenerable transcodes. It also does not include repository metadata,
-tests, linter reports, media/download libraries, observability storage, or
-dependencies.
+tests, media/download libraries, observability storage, or dependencies.
 
 ## Scheduling
 
@@ -143,9 +142,6 @@ Neither backup mode includes media/download libraries or repository-only state:
 
 - `.git/`
 - `tests/`
-- `megalinter-reports/` (nothing writes this since MegaLinter was replaced by
-  pre-commit hooks; the exclusion is kept because `tar` walks the filesystem,
-  so a stale copy in an older clone would otherwise be archived)
 - `data/` (includes `data/media/`, the actual media library)
 - `storage/`
 - `cache/`

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -61,7 +61,6 @@ def _fixture(root: Path) -> None:
 
     _write(root / ".git/config", "[core]\n")
     _write(root / "tests/test_placeholder.py", "def test_placeholder(): pass\n")
-    _write(root / "megalinter-reports/report.txt", "report\n")
     _write(root / "data/torrents/file", "download\n")
 
 
@@ -142,7 +141,6 @@ def test_backup_full_keeps_app_artwork_but_not_repo_or_media_state(tmp_path):
     assert "configs/jellyfin/config/.aspnet/DataProtection-Keys/key.xml" not in names
     assert ".git/config" not in names
     assert "tests/test_placeholder.py" not in names
-    assert "megalinter-reports/report.txt" not in names
     assert "data/torrents/file" not in names
 
 


### PR DESCRIPTION
# Pull Request

## What

- Documents why `megalinter-reports/` still appears in `.gitignore`, the
  Makefile's `COMMON_BACKUP_EXCLUDES`, and `docs/BACKUP.md`, now that nothing
  writes that directory.
- No behaviour change. Comments and one documentation line only.

## Why

- Every remaining reference reads as leftovers from the MegaLinter removal, and
  the reason they are deliberate lived only in a conversation. The next person
  to tidy them would be removing a live guard.
- A clone made before PR #50 still has the directory on disk. `.gitignore` keeps
  it out of a `git add -A`, which is the case with a permanent public
  consequence. The backup excludes it because `tar` walks the filesystem rather
  than asking git, which is the same reason `cache`, `logs` and `node_modules`
  are in that list despite being gitignored.
- `tests/test_backup.py` asserts the exclusion, so it stays too. The three move
  together or not at all, and the note says when to remove all of them.

## References

- The Makefile comment sits above the variable rather than beside the flag on
  purpose: the exclude list is one backslash-continued logical line, so a `#`
  among the flags would comment out every exclude after it. Verified by
  expanding the variable, 17 flags before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Full backups now include the `megalinter-reports/` directory and its contents.
* **Documentation**
  * Updated backup documentation to reflect that linter reports are no longer excluded.
  * Clarified backup exclusion guidance and retained legacy-directory handling notes.
* **Tests**
  * Updated backup coverage to match the new inclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->