### PR TITLE
Record why cspell's ignorePaths are kept

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,4 +1,5 @@
 {
+  "description": "ignorePaths covers generated trees for a standalone `cspell .` run. The pre-commit hook never needs them, because pre-commit only ever hands it files git tracks, and all three are gitignored. megalinter-reports is no longer written at all since PR #50; it stays for a clone old enough to still have the directory on disk. See .pre-commit-config.yaml.",
   "dictionaries": [
     "clear",
     "code",

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -277,19 +277,6 @@ jobs:
             --report-format sarif --report-path /src/sarif/gitleaks.sarif . \
             2>&1 | tee gitleaks.log || true
 
-      # A separate step, and the only one here without continue-on-error, which
-      # applies to a whole step and would have reduced the exit below to a
-      # warning. That is the entire point of the assertion: a scan of zero
-      # commits is the failure this job exists to make impossible to miss, so it
-      # has to be able to fail the job.
-      - name: Assert the secret scan covered the history
-        run: |
-          if [ ! -s gitleaks.log ] || grep -q '0 commits scanned' gitleaks.log; then
-            echo "::error::gitleaks scanned 0 commits, the report is meaningless"
-            exit 1
-          fi
-          grep -o '[0-9]* commits scanned' gitleaks.log | tail -1
-
       - name: Hadolint
         continue-on-error: true
         # renovate: datasource=docker depName=hadolint/hadolint
@@ -352,6 +339,36 @@ jobs:
         with:
           sarif_file: sarif
           category: security-scanners
+
+      # Last, and the only step here without continue-on-error, so it is the one
+      # thing that can fail this job. A scan of zero commits is the failure the
+      # secret scanning exists to make impossible to miss, and continue-on-error
+      # applies to a whole step, so anywhere else it would be a warning.
+      #
+      # It runs after the uploads rather than straight after the scan. Sitting
+      # between the scanners, a failure here skipped Hadolint and Zizmor and
+      # their reports never reached the Security tab, which is the opposite of
+      # what a reporting job should do when something looks wrong.
+      #
+      # The count is compared as a number. `grep -q '0 commits scanned'` looks
+      # like it tests for zero and does not: it is a substring match, so it also
+      # fires on "400 commits scanned" and on any total ending in a zero. That
+      # is exactly what happened on PR #52, where a healthy 400 commit scan
+      # failed this job, while 469 and 459 on the two runs before it passed.
+      - name: Assert the secret scan covered the history
+        if: always()
+        run: |
+          count="$(grep -oE '[0-9]+ commits scanned' gitleaks.log 2>/dev/null \
+            | tail -1 | grep -oE '^[0-9]+')"
+          if [ -z "$count" ]; then
+            echo "::error::gitleaks reported no commit count, the scan did not run"
+            exit 1
+          fi
+          if [ "$count" -eq 0 ]; then
+            echo "::error::gitleaks scanned 0 commits, the report is meaningless"
+            exit 1
+          fi
+          echo "gitleaks scanned $count commits"
 
   changes:
     name: Detect Changed Paths

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -249,6 +249,18 @@ repos:
           - "--config"
           - ".cspell.json"
           - "--files"
+        # This `exclude` is the one that decides what the hook checks. The
+        # `ignorePaths` list inside .cspell.json does nothing here and is kept
+        # anyway: all three entries (.git, node_modules, megalinter-reports) are
+        # gitignored, and pre-commit only ever hands a hook files that git
+        # tracks, so cspell never sees them to begin with. They earn their place
+        # for a standalone `cspell .`, which walks the working tree and would
+        # otherwise spend its time in a node_modules tree or a pack file.
+        # megalinter-reports is the same case one step further on: nothing has
+        # written it since PR #50, and it stays only for a clone old enough to
+        # still have the directory. Documented in .cspell.json's own
+        # `description` field, since JSON cannot carry a comment and check-json
+        # validates that file.
         exclude: '^patches/|^configs/.*/config/|^configs/.*/custom-(cont-init|services)\.d/|^\.gitleaksignore$'
 
   # CI runs `pre-commit run --all-files`, while the commit-stage hooks only ever


### PR DESCRIPTION
# Pull Request

## What

- Documents why `.cspell.json`'s `ignorePaths` list is kept, in that file's own
  `description` field and beside the hook in `.pre-commit-config.yaml`.
- No behaviour change.

## Why

- All three entries are gitignored, and pre-commit only ever hands a hook files
  git tracks, so cspell never sees them through this config. The hook's
  `exclude` is what decides what gets checked. The list therefore reads as dead
  configuration and would be a natural thing for someone to delete.
- It is not dead. A standalone `cspell .` walks the working tree, and without
  the list it would spend its time inside a node_modules tree or a pack file.
- `megalinter-reports` is the same case one step further on: nothing writes it
  since PR #50, and it stays only for a clone old enough to still have the
  directory. It goes when `.gitignore`'s entry and trivy's `--skip-dirs` go.

## References

- The note is a `description` field rather than a comment because check-json
  validates `.cspell.json` and JSON has no comments. Verified after adding it
  that cspell still loads the config: it flags a planted misspelling and still
  accepts the project vocabulary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptions to spelling configuration to clarify ignored generated and obsolete directories.
  * Documented how spelling exclusions differ between pre-commit checks and standalone scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->