### PR TITLE
Lift the weekly window so a bot pull request can be tested now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,30 @@
   dependencyDashboard: false,
 
   timezone: "America/Toronto",
-  schedule: ["before 7am on Monday"],
+
+  // TEMPORARY. Restore `schedule: ["before 7am on Monday"]` when the CodeRabbit
+  // question below is settled.
+  //
+  // Why it is off: on 2026-08-17 three dependency bot pull requests went more
+  // than ten hours without a CodeRabbit review, a comment, or even a
+  // `CodeRabbit` status, while every human pull request that day got one within
+  // minutes. Asked directly, CodeRabbit answered #56 in under three minutes, so
+  // the capability is there. GitHub also ran a critical incident that day,
+  // 13:40Z to 21:15Z, with Webhooks among the affected components, which would
+  // produce exactly that silence, so the observation is unusable and has to be
+  // repeated on a clean day.
+  //
+  // Repeating it needs a bot pull request, and the weekly window is what stops
+  // one existing: it only permits branch creation between midnight and 7am on a
+  // Monday, so the next natural opportunity is a week away. Nothing else about
+  // the policy moves. minimumReleaseAge still holds every update for seven
+  // days, and prConcurrentLimit and prHourlyLimit still bound how much arrives
+  // at once.
+  //
+  // Worth weighing before restoring it: the window costs up to seven days on
+  // top of the seven the cooling period already imposes, and it was there to
+  // give a person one sitting a week to work through the batch. Nothing is
+  // worked through by hand any more.
 
   labels: ["dependencies", "docker"],
   commitMessagePrefix: "chore:",


### PR DESCRIPTION
**Temporary.** Restore `schedule: ["before 7am on Monday"]` once the CodeRabbit question is answered. The file carries the same note so it explains itself if we forget.

## Why

Three dependency bot PRs (#53, #54, #55) went more than ten hours on 2026-08-17 with no CodeRabbit review, no comment, and no `CodeRabbit` status, while every human PR that day got one within minutes. Asked directly, CodeRabbit answered #56 in under three minutes, so the capability is plainly there.

But GitHub ran a **critical incident that day, 13:40:03Z to 21:15:46Z, with Webhooks among the affected components** alongside Pull Requests, API Requests and Actions. A dropped `pull_request` webhook produces exactly that silence, where a rate limit would have posted a banner. So the observation is unusable and has to be repeated on a clean day.

## Why this change is what unblocks the retest

Repeating it needs a bot PR to exist, and the weekly window is what prevents one: branch creation is only permitted between midnight and 7am on a Monday, and it is now Monday evening in Toronto, so the next natural opportunity is a week out. checkov 3.3.11 is already waiting behind the cooling period and clears it on the 20th.

Nothing else about the policy moves. `minimumReleaseAge` still holds every update for seven days, and `prConcurrentLimit` and `prHourlyLimit` still bound how much arrives at once.

## Worth weighing before restoring it

The window costs up to seven days on top of the seven the cooling period already imposes, so a fix can be a fortnight old before it lands. It existed to give a person one sitting a week to work through the batch, and nothing is worked through by hand any more.