### PR TITLE
Accept hash-style tags, and stop piling up approvals

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -56,10 +56,18 @@ jobs:
     # contains: `renovate[bot]-x` is a login somebody may register, and the
     # non-fork condition is the second half of the same fence, since reaching
     # this job any other way would take write access to this repository.
+    #
+    # The label condition is about noise rather than correctness. `labeled`
+    # fires once per label, Renovate applies three, and with `opened` as well
+    # #61 collected seven identical approvals before anything had even run. Only
+    # the label this job actually reads is worth waking it for.
     if: >-
       github.event.pull_request.head.repo.fork == false && (
         github.event.pull_request.user.login == 'renovate[bot]' ||
         github.event.pull_request.user.login == 'dependabot[bot]'
+      ) && (
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'automerge'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -171,10 +179,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         # Re-approved on every push, which is required rather than wasteful:
         # branch protection dismisses stale reviews, so a rebase drops the
         # previous approval, and `synchronize` is above for that reason.
-        run: gh pr review --approve "$PR_URL"
+        #
+        # Skipped when a live approval is already there, which is what stops the
+        # remaining events piling identical reviews onto one pull request. A
+        # dismissed one does not count, so a rebase still earns a fresh
+        # approval, which is the whole point of re-running.
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Already approved and not dismissed. Nothing to do."
+            exit 0
+          fi
+          gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge
         if: steps.decide.outputs.arm == 'true'

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -71,6 +71,14 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # One at a time per pull request. The guard below reads the reviews and then
+    # writes one, so two runs racing between those two steps would both see no
+    # approval and both add one, which is the pile-up this is meant to end.
+    # Queued rather than cancelled: a superseded run here has nothing to redo,
+    # but a cancelled one might have been the only run that would have approved.
+    concurrency:
+      group: bot-auto-merge-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       # For `gh pr merge --auto` on the Dependabot path only. Arming auto-merge
       # does not merge anything: every required check still has to pass, and
@@ -192,8 +200,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          # --paginate, because the REST reviews endpoint returns one page and
+          # #61 had already collected seven reviews before this guard existed.
+          # The jq runs per page under --paginate, so the slurp happens outside
+          # it: `gh api` refuses --slurp and --jq together.
+          existing=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
           if [ "$existing" -gt 0 ]; then
             echo "Already approved and not dismissed. Nothing to do."
             exit 0

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -75,15 +75,22 @@ DIGEST = re.compile(r"@(?:sha256:[0-9a-f]{7,}|[0-9a-f]{40})")
 #                        YAML `key: 25` cannot pass for one
 # The prefix is captured and put back, so that a pin changing shape rather than
 # value, `foo==1.2.3` becoming `foo@1.2.3`, still reads as a difference.
-# The token itself starts with a digit and may then be any mix of letters and
-# digits, because a version is not always dotted numbers. linuxserver publishes
-# lazylibrarian as `40a389ea-ls310`, a commit hash with a build suffix, and an
-# earlier pattern of `\d+(\.\d+)*` matched only the leading `40` there, leaving
-# `a389ea-ls309` and `a389ea-ls310` to compare as literal text. The assertion
-# refused its own PR #62, correctly by its own rules and wrongly in fact.
+# The token is any tag-shaped run of characters, and the narrowing lives entirely
+# in the prefix rather than in the shape. Two rounds of guessing at the shape
+# were both wrong: `\d+(\.\d+)*` matched only the `40` of lazylibrarian's
+# `40a389ea-ls310` and refused PR #62, and requiring a leading digit still
+# refused `KORSYNC_VERSION=sha-7bcefd34...`, which is what korsync is pinned to
+# right now. `stable-alpine` and `latest` are in .env.example too.
+#
+# Being this permissive about the value costs nothing, because whatever is being
+# pinned is always named to the *left* of the prefix and stays literal:
+# `actions/checkout@v7` becoming `attacker/checkout@v7` still fails, as does
+# `checkov==3.3.2` becoming `evil==3.3.2`. What a bump is allowed to change is
+# the value in a pin position, and only there, which is why `PUID=1000` is
+# untouched by this and a change to it is refused.
 VERSION = re.compile(
     r"(?P<prefix>==|@|(?<=VERSION)=|\brev:[ \t]+|(?<=\S):)"
-    r"v?\d[0-9A-Za-z]*(?:[.\-+_][0-9A-Za-z]+)*"
+    r"[0-9A-Za-z][0-9A-Za-z.+_-]*"
 )
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -75,9 +75,15 @@ DIGEST = re.compile(r"@(?:sha256:[0-9a-f]{7,}|[0-9a-f]{40})")
 #                        YAML `key: 25` cannot pass for one
 # The prefix is captured and put back, so that a pin changing shape rather than
 # value, `foo==1.2.3` becoming `foo@1.2.3`, still reads as a difference.
+# The token itself starts with a digit and may then be any mix of letters and
+# digits, because a version is not always dotted numbers. linuxserver publishes
+# lazylibrarian as `40a389ea-ls310`, a commit hash with a build suffix, and an
+# earlier pattern of `\d+(\.\d+)*` matched only the leading `40` there, leaving
+# `a389ea-ls309` and `a389ea-ls310` to compare as literal text. The assertion
+# refused its own PR #62, correctly by its own rules and wrongly in fact.
 VERSION = re.compile(
     r"(?P<prefix>==|@|(?<=VERSION)=|\brev:[ \t]+|(?<=\S):)"
-    r"\bv?\d+(?:\.\d+)*(?:[-.+][0-9A-Za-z.+_-]+)?\b"
+    r"v?\d[0-9A-Za-z]*(?:[.\-+_][0-9A-Za-z]+)*"
 )
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -230,3 +230,26 @@ def test_refuses_a_pin_that_changes_shape_rather_than_value():
         )
     )
     assert result.returncode == 1
+
+
+def test_accepts_a_hash_style_tag():
+    # linuxserver publishes lazylibrarian as a commit hash with a build suffix,
+    # not as dotted numbers. Refusing that meant refusing a real bump, which is
+    # what happened to #62.
+    result = _check(
+        _diff(
+            ".env.example",
+            # pragma: allowlist secret - an image tag, and the hash in it is
+            # what detect-secrets reads as entropy. It is published on Docker
+            # Hub.
+            "-LAZYLIBRARIAN_VERSION=40a389ea-ls309\n"  # pragma: allowlist secret
+            "+LAZYLIBRARIAN_VERSION=40a389ea-ls310\n",  # pragma: allowlist secret
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_still_refuses_a_non_pin_number_after_widening_the_token():
+    # The widened token must not start accepting numbers that are not pins.
+    result = _check(_diff(".env.example", "-PUID=1000\n+PUID=0\n"))
+    assert result.returncode == 1

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -253,3 +253,34 @@ def test_still_refuses_a_non_pin_number_after_widening_the_token():
     # The widened token must not start accepting numbers that are not pins.
     result = _check(_diff(".env.example", "-PUID=1000\n+PUID=0\n"))
     assert result.returncode == 1
+
+
+def test_accepts_a_sha_prefixed_tag():
+    # korsync is pinned to `sha-<hash>`, so the token cannot be required to
+    # start with a digit. Requiring one refused this form.
+    old = "sha-7bcefd34e9f6738ce34ccda338aedd316baa05c9"  # pragma: allowlist secret
+    new = "sha-8adf1129c7a0d51e0b2a7f4e93a1b0c5d6e7f809"  # pragma: allowlist secret
+    result = _check(
+        _diff(".env.example", f"-KORSYNC_VERSION={old}\n+KORSYNC_VERSION={new}\n")
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_a_floating_tag_change():
+    result = _check(
+        _diff(".env.example", "-NGINX_VERSION=stable-alpine\n+NGINX_VERSION=stable\n")
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_still_refuses_a_swapped_image_name_with_the_widest_token():
+    # The name sits left of the prefix and stays literal, which is what keeps
+    # the permissive token safe.
+    result = _check(
+        _diff(
+            ".pre-commit-config.yaml",
+            "-        entry: docker run aquasec/trivy:0.71.2\n"
+            "+        entry: docker run attacker/trivy:0.71.2\n",
+        )
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
Two defects the first unattended Renovate PRs exposed, both mine.

## The pin assertion refused a real bump (#62)

`LAZYLIBRARIAN_VERSION=40a389ea-ls309` to `-ls310`. linuxserver tags that image with a commit hash and a build suffix rather than dotted numbers, and the version token was `\d+(\.\d+)*`, so it matched the leading `40` and left `a389ea-ls309` against `a389ea-ls310` to compare as literal text:

```
REFUSED: this diff changes more than dependency pins.
  .env.example: added a line that was not a version bump: +LAZYLIBRARIAN_VERSION=40a389ea-ls310
```

It failed closed, so nothing unsafe happened and #62 simply waited, but it waited for no reason. The token now starts with a digit and may carry letters. Both live PRs pass, and `PUID=1000` becoming `PUID=0` is still refused, which is the property the narrowing existed for in the first place.

## #61 collected seven identical approvals

`labeled` fires once per label, Renovate applies three, and `opened` fires too. The job now wakes on the `automerge` label only, and the approve step checks for a live approval before adding another. A dismissed approval does not count, so a rebase still earns a fresh one, which is what `synchronize` is there for.

## Verification

18 tests, including the hash-style tag and a re-assertion that a non-pin number is still refused. Both open bot PRs (#61, #62) pass the assertion with the fix applied locally.

## Not in this PR

- **#61 is legitimately red.** SABnzbd 5.0.4 rewrites its own config `host` from `0.0.0.0` to `::`, and `test_sabnzbd_config_disables_ipv6` catches it. That is the IPv6 leak `docs/HARDENING.md` documents pinning against, so it needs a decision rather than a workaround.
- **CodeRabbit still does not auto-review bot PRs**, now confirmed on a clean day. See the PR discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated merge approvals to run only for relevant labels.
  * Prevented duplicate approvals when an existing approval is detected.
  * Expanded supported image tag formats, including hash-style tags and build suffixes.
  * Continued rejecting unrelated numeric changes that are not image pin updates.

* **Tests**
  * Added coverage for hash-style tag updates and non-pin numeric changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->