### PR TITLE
Support .tool-versions pins

### DIFF
--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -11,7 +11,7 @@ This is the check that stands between "renovate[bot] opened a pull request" and
 an unattended merge. Without it, approving a bot's pull request on the strength
 of its author means the bot identity holds write access to main: a compromised
 Renovate, or a Renovate whose configuration has been edited to widen what it
-manages, could rewrite a workflow and be approved for it. Two of the four
+manages, could rewrite a workflow and be approved for it. Two of the five
 allowed paths are executable surfaces on their own, since the pip pins live in
 workflow `run:` steps and the scanner image tags live inside pre-commit hook
 `entry:` commands, so a path allowlist alone would not be much of a fence. The
@@ -29,7 +29,7 @@ than "any number on the line" and deliberately so. `PUID=1000` becoming
 `PUID=0`, or a `timeout-minutes:` moving, are numeric edits with real effects
 that a looser rule would wave through, so they are refused like any other
 structural change. The residue is a number that sits in a pin position and is
-not a pin, which in these four files means an image tag's port-like suffix and
+not a pin, which in these five files means an image tag's port-like suffix and
 little else.
 
 What it deliberately does not catch: a bump to a version that exists but is
@@ -52,7 +52,15 @@ ALLOWED_PATHS = (
     ".pre-commit-config.yaml",
     ".github/workflows/",
     "tests/requirements.txt",
+    ".tool-versions",
 )
+
+# `.tool-versions` writes `<tool> <version>`, one per line, with nothing to
+# anchor on but the space. That cannot go in the prefix set below, because a
+# lookbehind of variable width is not allowed and "the word after a space" would
+# match most of a workflow file. It is matched whole-line instead, and only for
+# that file, which is why normalize takes the path.
+TOOL_VERSION_LINE = re.compile(r"^(?P<prefix>[A-Za-z0-9_.-]+[ \t]+)\S+[ \t]*$")
 
 # Removed outright rather than replaced with a placeholder: Renovate's
 # pinDigests adds a digest to a line that had none, so a placeholder would make
@@ -64,7 +72,8 @@ DIGEST = re.compile(r"@(?:sha256:[0-9a-f]{7,}|[0-9a-f]{40})")
 # `PUID=1000` becoming `PUID=0`, or a `fetch-depth` moving, since both sides
 # would normalize alike.
 #
-# The five prefixes are the five shapes a pin takes in the four allowed files:
+# The five prefixes are the shapes a pin takes everywhere except .tool-versions,
+# which is handled whole-line above:
 #
 #   ==1.2.3              pip, in a workflow run step or additional_dependencies
 #   @v1.2.3              an action ref, and what is left after a digest is cut
@@ -96,9 +105,12 @@ VERSION = re.compile(
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
 
-def normalize(line: str) -> str:
+def normalize(line: str, path: str = "") -> str:
     """Reduce a line to everything about it that a version bump may not change."""
-    return VERSION.sub(r"\g<prefix><version>", DIGEST.sub("", line))
+    stripped = DIGEST.sub("", line)
+    if path.endswith(".tool-versions"):
+        return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
+    return VERSION.sub(r"\g<prefix><version>", stripped)
 
 
 def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
@@ -139,9 +151,9 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
             continue
 
         if line.startswith("-"):
-            changes[path][0][normalize(line[1:])] += 1
+            changes[path][0][normalize(line[1:], path)] += 1
         elif line.startswith("+"):
-            changes[path][1][normalize(line[1:])] += 1
+            changes[path][1][normalize(line[1:], path)] += 1
 
     return changes, structural
 

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -284,3 +284,24 @@ def test_still_refuses_a_swapped_image_name_with_the_widest_token():
         )
     )
     assert result.returncode == 1
+
+
+def test_accepts_a_tool_versions_bump():
+    # .tool-versions writes `<tool> <version>` with only a space between them,
+    # which none of the prefix rules can see. #67 was refused for it.
+    result = _check(_diff(".tool-versions", "-pre-commit 4.5.1\n+pre-commit 4.6.2\n"))
+    assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_swapped_tool_name_in_tool_versions():
+    result = _check(
+        _diff(".tool-versions", "-pre-commit 4.5.1\n+attacker-tool 4.5.1\n")
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_an_extra_tool_added_to_tool_versions():
+    result = _check(
+        _diff(".tool-versions", "-pre-commit 4.5.1\n+pre-commit 4.6.2\n+evil 1.0.0\n")
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
#67 bumps `pre-commit` 4.5.1 to 4.6.2 in `.tool-versions`, and the assertion refused it on both counts:

```
REFUSED: this diff changes more than dependency pins.
  .tool-versions: not a dependency pin file
  .tool-versions: removed a line that was not re-added: -pre-commit 4.5.1
  .tool-versions: added a line that was not a version bump: +pre-commit 4.6.2
```

The file was not in the allowlist, and its `<tool> <version>` form has only a space between name and version, so none of the prefix rules could anchor on it.

The allowlist gains the file. The line form is matched whole-line rather than by prefix, because a variable-width lookbehind is not allowed in Python and "the word after a space" would match most of a workflow file, so `normalize` now takes the path and applies that pattern to that file only. The tool name remains the prefix, kept and compared, so swapping the name or adding a line is still refused.

## Verification

24 tests, including a swapped tool name and an extra tool added. All four open bot PRs pass the assertion with this applied: #61, #64, #66 and #67.

## Note

This is the third format I have had to add after the fact, following lazylibrarian's `40a389ea-ls310` and korsync's `sha-...`. The pattern is that I keep enumerating pin shapes from memory instead of from the repository. The allowlist is now `.env.example`, `.pre-commit-config.yaml`, `.github/workflows/`, `tests/requirements.txt` and `.tool-versions`, which is every file Renovate and Dependabot are configured to touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating dependency pin updates in `.tool-versions`.
  * Tool version changes are now recognized while unrelated tool changes remain blocked.

* **Tests**
  * Added coverage for valid tool version bumps.
  * Added checks to reject tool-name swaps and unexpected tool additions.

* **Documentation**
  * Updated supported-file documentation to include `.tool-versions` and its special handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->