### PR TITLE
Bound the steps that reach the network

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -242,15 +242,18 @@ jobs:
     needs: gate
     if: needs.gate.outputs.authorized == 'true'
     runs-on: ubuntu-latest
-    # Measured, not guessed: eight consecutive passing runs took 11 or 12
-    # minutes each, so 20 is roughly seventy percent of headroom on the worst of
-    # them. It was 25, which is nearly an hour of runner time on two stuck runs
-    # before anyone notices.
+    # Measured from the steps of a passing run rather than from run timestamps,
+    # which was the earlier mistake: the run level figure read 11 or 12 minutes
+    # while the steps actually sum to 14.8. So 20 is about a third of headroom,
+    # not the two thirds it was first claimed to be, and it should not come down
+    # further without shortening the suite itself. It was 25 before that.
     #
-    # This is the binding limit, not the per-step ones below. Those sum to well
-    # over an hour, because each has to allow for its own worst case, so the job
-    # cap is always what a genuinely stuck run hits first. That is fine now that
-    # hitting it reports a failure rather than nothing; see the publish job.
+    # This stays the binding limit, and the per-step limits below are not trying
+    # to replace it. They sum past an hour because each allows for its own worst
+    # case. What they buy is that a single stalled step dies in two or three
+    # minutes instead of spending the whole budget, which is exactly what
+    # `apt-get update` did twice on #68, hanging the full twenty while every
+    # later step was skipped. Nothing in the suite job is unbounded now.
     timeout-minutes: 20
     # One suite per pull request: a second `/run-tests`, or a push to a bot's
     # branch, supersedes the first rather than standing a competing stack up on
@@ -287,6 +290,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
+        timeout-minutes: 2
         uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ needs.gate.outputs.pr_number }}/merge
@@ -299,6 +303,7 @@ jobs:
           persist-credentials: false
 
       - name: Prove this is the head the status will describe
+        timeout-minutes: 1
         # refs/pull/N/merge is recomputed on every push to the pull request, so
         # a push landing between the gate resolving head.sha and this checkout
         # would test one commit and publish a result for another. The merge
@@ -332,7 +337,7 @@ jobs:
         # and three attempts covers a mirror that is briefly unreachable rather
         # than down. The explicit timeouts on apt itself are what make a stall
         # fail fast enough for the retry to be worth having.
-        timeout-minutes: 6
+        timeout-minutes: 3
         shell: bash
         run: |
           set -euo pipefail
@@ -352,7 +357,7 @@ jobs:
         # Bounded for the same reason as the xmlstarlet step above: this one
         # also talks to the archive, so a stalled mirror here would spend the
         # job budget rather than this step's.
-        timeout-minutes: 8
+        timeout-minutes: 6
         # See prerequisites job's own copy of this step for why it's
         # needed. This is the runtime the project is actually built and
         # documented for; every local bench validation this session ran
@@ -442,6 +447,7 @@ jobs:
           timeout 30 bash -c 'until [ -S "/run/user/'"$(id -u)"'/podman/podman.sock" ]; do sleep 1; done'
 
       - name: Create .env file
+        timeout-minutes: 2
         shell: bash
         run: |
           cp .env.example .env
@@ -451,6 +457,7 @@ jobs:
           sed -i 's/^LAN_IP=192.168.1.x/LAN_IP=192.168.1.100/' .env
 
       - name: Point the VPN at the local mock
+        timeout-minutes: 2
         # Always the mock, never a real credential. There is no
         # PROTONVPN_PRIVATE_KEY secret in this repository and there is not going
         # to be one: the mock is what validates the VPN, here and in
@@ -477,11 +484,12 @@ jobs:
           ./scripts/seed-vpn-mock.sh
 
       - name: Read PYTHON_VERSION from .env
+        timeout-minutes: 1
         shell: bash
         run: grep -m1 '^PYTHON_VERSION=' .env >> "$GITHUB_ENV"
 
       - name: Python Setup
-        timeout-minutes: 5
+        timeout-minutes: 4
         uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -507,11 +515,11 @@ jobs:
         # first Docker Hub pull. A run stalled here for over four minutes,
         # having previously stalled in Start stack, which is the same cause
         # wearing a different step name.
-        timeout-minutes: 8
+        timeout-minutes: 4
         run: make seed_all
 
       - name: Generate self-signed certificate
-        timeout-minutes: 3
+        timeout-minutes: 2
         run: make generate_certificate
 
       - name: Log in to Docker Hub
@@ -553,7 +561,7 @@ jobs:
         # has just been hit is the kind of failure that clears on its own.
         # `make pull_docker_images` is idempotent, so a retry resumes rather
         # than starting over.
-        timeout-minutes: 12
+        timeout-minutes: 6
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -574,7 +582,7 @@ jobs:
         # whole budget and reported nothing about which one it was. These sum
         # to more than 25 deliberately: the job cap stays the outer bound, and
         # these exist to name the culprit, not to replace it.
-        timeout-minutes: 10
+        timeout-minutes: 5
         # The step timing out on its own says only that something hung: the log
         # ends on a container name with nothing after it, which is what four
         # runs in a row reported. Interrupting a little before the cap and
@@ -597,7 +605,7 @@ jobs:
           fi
 
       - name: Wait for containers to be ready
-        timeout-minutes: 7
+        timeout-minutes: 5
         # Reads straight from `podman ps`, not through a compose wrapper:
         # podman's own --format json is a single JSON array with health
         # folded into the free-text Status field ("Up 3 minutes
@@ -630,7 +638,7 @@ jobs:
         # nothing but a seeded placeholder, confirmed live as the cause of
         # this job's own Homepage widget failures. make bootstrap always runs
         # this straight after make start for the same reason.
-        timeout-minutes: 10
+        timeout-minutes: 4
         run: make wire_connections
 
       - name: Run integration tests
@@ -649,12 +657,12 @@ jobs:
         # The wiring_readonly subset does run here: it reads back what the
         # wire_connections step above just wired, and restarts nothing. See
         # the Makefile's own comment on test_ci.
-        timeout-minutes: 12
+        timeout-minutes: 9
         run: make test_ci
 
       - name: Tear down
         if: always()
-        timeout-minutes: 5
+        timeout-minutes: 3
         run: make stop_all
 
   publish:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -320,10 +320,39 @@ jobs:
           fi
 
       - name: Install xmlstarlet
+        # Bounded and retried, because this innocuous line has cost two suite
+        # runs. On 2026-08-18 it hung for the whole twenty minute job budget on
+        # #68, twice, while every step after it was skipped: `apt-get update`
+        # stalls on an unreachable mirror and waits out its own long default
+        # timeouts. A step with no limit of its own inside a job whose limit is
+        # the only backstop turns a mirror hiccup into a failed suite, and the
+        # publish job can only report that the run did not finish.
+        #
+        # Two minutes is generous for two apt calls that normally take seconds,
+        # and three attempts covers a mirror that is briefly unreachable rather
+        # than down. The explicit timeouts on apt itself are what make a stall
+        # fail fast enough for the retry to be worth having.
+        timeout-minutes: 6
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+        run: |
+          set -euo pipefail
+          apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
+          for attempt in 1 2 3; do
+            if sudo apt-get "${apt_opts[@]}" update \
+              && sudo apt-get "${apt_opts[@]}" install -y xmlstarlet; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed, retrying."
+            sleep 5
+          done
+          echo "::error::Could not install xmlstarlet after three attempts."
+          exit 1
 
       - name: Set up rootless Podman
+        # Bounded for the same reason as the xmlstarlet step above: this one
+        # also talks to the archive, so a stalled mirror here would spend the
+        # job budget rather than this step's.
+        timeout-minutes: 8
         # See prerequisites job's own copy of this step for why it's
         # needed. This is the runtime the project is actually built and
         # documented for; every local bench validation this session ran
@@ -452,11 +481,13 @@ jobs:
         run: grep -m1 '^PYTHON_VERSION=' .env >> "$GITHUB_ENV"
 
       - name: Python Setup
+        timeout-minutes: 5
         uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install scripts/permissions.py's dependency
+        timeout-minutes: 3
         # seed_all's own permissions_repair step runs this script directly
         # with the system Python, not tests/.venv (that only gets created
         # later, by make test's own dependency on it).


### PR DESCRIPTION
## What happened

`Install xmlstarlet` hung for the entire twenty minute job budget on #68, twice in a row:

```
success    17:52:17   Prove this is the head the status will describe
cancelled  18:12:26   Install xmlstarlet
skipped    18:12:26   Set up rootless Podman
skipped    ...        (every remaining step)
```

The step is `sudo apt-get update && sudo apt-get install -y xmlstarlet`, normally a few seconds. It had no `timeout-minutes` of its own, so a stalled mirror spent the whole suite and the only thing the publish job could report was that the run did not finish. The 25 minute timeout seen the day before, which prompted #59, was very likely the same step.

## The fix

That step gets a six minute bound, three attempts, and explicit apt timeouts. The apt timeouts are the part that matters: without them apt waits out its own long defaults and a retry never gets a turn.

The other three steps that reach the network get bounds too, the podman archive install at 8, `setup-python` at 5, and the pip install at 3. Steps that only touch local files are left alone, since they cannot hang on a mirror and a limit on each would be noise.

## On the job cap

It stays the binding limit, deliberately. Step limits sum to well over an hour because each has to allow for its own worst case, so the job cap is what a genuinely slow run hits. What step limits buy is different: a single hung step fails on its own instead of taking the suite with it, which is exactly what went wrong here.

## Worth noting

Two mechanisms added earlier this week did their jobs here. #59's publish fix reported `failure` with "did not finish, timed out or was stopped" rather than leaving the context `pending` in silence, which is how this was noticed at all. And the 25 to 20 reduction in the same PR meant the wasted run cost 20 minutes instead of 25.