### PR TITLE
Close out the Renovate hygiene work

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -250,6 +250,36 @@
     },
     {
       customType: "regex",
+      // The `additional_dependencies` pins in .pre-commit-config.yaml: gitleaks
+      // (a Go module) and checkov (a pypi package). Neither is a container
+      // image, which is the whole reason this is its own manager.
+      //
+      // These used to sit alongside the image patterns below, under that
+      // manager's `datasourceTemplate: "docker"`. A template set on a manager
+      // applies to every one of its matchStrings and wins over a `datasource`
+      // captured by the pattern, so the annotations here were read and then
+      // overridden, and Renovate spent weeks reporting:
+      //
+      //   Failed to look up docker package github.com/zricethezav/gitleaks/v8
+      //   Failed to look up docker package checkov
+      //
+      // Silently, on the repository's Renovate dashboard rather than anywhere
+      // this repository would notice. Meanwhile the second copy of the checkov
+      // pin, in the workflow, updates through a different manager that has no
+      // template, so the two drifted: the gate was still on 3.3.2 while the
+      // SARIF report had reached 3.3.10. That is exactly the failure the
+      // manager below warns about.
+      //
+      // No datasourceTemplate here, deliberately. The annotation is the
+      // authority, and it is the only thing that can be, because the two
+      // dependencies do not share a datasource.
+      managerFilePatterns: ["/^\\.pre-commit-config\\.yaml$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*additional_dependencies: \\[\"[^\"]+?(?:==|@)(?<currentValue>v?[0-9][^\"]*)\"\\]",
+      ],
+    },
+    {
+      customType: "regex",
       // Versions pinned inside `repo: local` hooks in .pre-commit-config.yaml.
       //
       // Dependabot's pre-commit ecosystem updates the `rev:` of a hook
@@ -280,7 +310,6 @@
         "/^\\.github/workflows/pull-request-validation\\.yml$/",
       ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*additional_dependencies: \\[\"[^\"]+?(?:==|@)(?<currentValue>v?[0-9][^\"]*)\"\\]",
         "# renovate: datasource=docker depName=(?<depName>aquasec/trivy)[\\s\\S]{0,900}?aquasec/trivy:(?<currentValue>v?\\d[\\w.\\-]*)",
         "# renovate: datasource=docker depName=(?<depName>dotenvlinter/dotenv-linter)[\\s\\S]{0,900}?dotenvlinter/dotenv-linter:(?<currentValue>v?\\d[\\w.\\-]*)",
         "# renovate: datasource=docker depName=(?<depName>zricethezav/gitleaks)[\\s\\S]{0,900}?zricethezav/gitleaks:(?<currentValue>v?\\d[\\w.\\-]*)",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,29 +19,29 @@
 
   timezone: "America/Toronto",
 
-  // TEMPORARY. Restore `schedule: ["before 7am on Monday"]` when the CodeRabbit
-  // question below is settled.
+  // One window a week for creating branches, so the pull requests arrive
+  // together rather than trickling in.
   //
-  // Why it is off: on 2026-08-17 three dependency bot pull requests went more
-  // than ten hours without a CodeRabbit review, a comment, or even a
-  // `CodeRabbit` status, while every human pull request that day got one within
-  // minutes. Asked directly, CodeRabbit answered #56 in under three minutes, so
-  // the capability is there. GitHub also ran a critical incident that day,
-  // 13:40Z to 21:15Z, with Webhooks among the affected components, which would
-  // produce exactly that silence, so the observation is unusable and has to be
-  // repeated on a clean day.
+  // Only creating. updateNotScheduled defaults to true, so branches that
+  // already exist are still rebased outside the window, which matters here
+  // because required checks are strict: every merge puts the other open pull
+  // requests behind, and they would sit until the next Monday if Renovate could
+  // not touch them. This was misread once as a reason not to restore the window
+  // at all.
   //
-  // Repeating it needs a bot pull request, and the weekly window is what stops
-  // one existing: it only permits branch creation between midnight and 7am on a
-  // Monday, so the next natural opportunity is a week away. Nothing else about
-  // the policy moves. minimumReleaseAge still holds every update for seven
-  // days, and prConcurrentLimit and prHourlyLimit still bound how much arrives
-  // at once.
+  // Lifted briefly on 2026-08-18 to produce a bot pull request on demand, which
+  // is the only way to observe whether CodeRabbit auto-reviews one. It does not.
+  // Across 16 bot pull requests it posted a `CodeRabbit` status on exactly one,
+  // #56, which is the one asked by hand, while all 8 human pull requests in the
+  // same window got one automatically. GitHub's 2026-08-17 webhook incident is
+  // ruled out, since the retest ran hours after it resolved. Raised with their
+  // support.
   //
-  // Worth weighing before restoring it: the window costs up to seven days on
-  // top of the seven the cooling period already imposes, and it was there to
-  // give a person one sitting a week to work through the batch. Nothing is
+  // Worth weighing if this is ever reconsidered: the window costs up to seven
+  // days on top of the seven minimumReleaseAge already imposes, and it existed
+  // to give a person one sitting a week to work through the batch. Nothing is
   // worked through by hand any more.
+  schedule: ["before 7am on Monday"],
 
   labels: ["dependencies", "docker"],
   commitMessagePrefix: "chore:",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -349,7 +349,7 @@ repos:
           --directory .
         language: python
         # renovate: datasource=pypi depName=checkov
-        additional_dependencies: ["checkov==3.3.2"]
+        additional_dependencies: ["checkov==3.3.10"]
         stages: [pre-push]
         pass_filenames: false
         always_run: true

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -65,6 +65,27 @@ for what was fixed and when.
   `docker-compose-vpn.yml` actually relies on, so this patch is defense in depth
   and its removal is safe whenever upstream changes
 
+## Jellyfin wiring
+
+- [ ] Stop `ensure_jellyfin_connection` failing silently, and work out why it
+  fails for `lidarr`. `scripts/wire-connections.sh:1003` calls it with
+  `|| true`, so a failure leaves the app without the connection while `make wire_connections`
+  still reports success, and the first sign of it is
+  `test_jellyfin_connection_matches_what_the_app_supports[lidarr]` failing later
+  with `supports MediaBrowser=True but wired=False`. Seen on two runs on
+  2026-08-18 (`32176749677` on #72 and `32179005406` on #77), both shortly after
+  the Jellyfin 10.11.10 bump merged unattended in #76 at 19:17Z, and both passed
+  on a retry, so the bump appears to have widened a race rather than broken
+  anything outright. Two things to do, and the first stands on its own: the
+  Prowlarr path in the same file already collects failures in `PROWLARR_FAILED`
+  precisely "so the end of `wire_prowlarr_apps` can report them instead of
+  letting a partial result look identical to a complete one", and the Jellyfin
+  path should do the same rather than swallow. Then find the actual failure,
+  which the reporting will finally make visible. This matters more than a normal
+  flake now that dependency updates merge unattended: an intermittent test means
+  a bot pull request stalls at random and waits for a person, which is the one
+  outcome the automation exists to avoid
+
 ## LazyLibrarian
 
 - [ ] Drop `patches/lazylibrarian/lazylibrarian/auth.py` once it is no longer


### PR DESCRIPTION
Three related changes in one pull request rather than three, because strict checks mean each merge invalidates the next and this would otherwise cost three suite cycles. Supersedes #77 and #78, which I will close.

## 1. Restore the weekly window

Lifted in #60 to produce a bot pull request on demand, which was the only way to observe whether CodeRabbit auto-reviews one. It does not:

| | `CodeRabbit` status present |
|---|---|
| Human PRs | 8 of 8 |
| Bot PRs | 1 of 16, and that one was asked for by hand (#56) |

Four of the human statuses read "Review rate limited", which is what rules out quota: a throttled review still reports a status, while the bot PRs report nothing. Raised with CodeRabbit support.

The comment also records a mistake of mine. I held this back twice believing the window would freeze open bot PRs until Monday. `updateNotScheduled` defaults to `true`, so the schedule restricts *creating* branches, not updating existing ones.

## 2. Fix the pre-commit pin lookups, and resync checkov

Renovate's dashboard has been reporting:

```
Failed to look up docker package github.com/zricethezav/gitleaks/v8
Failed to look up docker package checkov
```

Neither is an image. Both are `additional_dependencies` pins, a Go module and a pypi package, and they sat in a manager whose `datasourceTemplate: "docker"` overrode the datasource their annotations declare. Verified by running the pattern against the file: it captures `go` and `pypi` correctly and the template was discarding both.

The consequence is the part that matters. The checkov pin exists twice, and only the workflow copy could resolve, so they drifted: **3.3.2 in the gate against 3.3.10 in the report**, which is exactly what that manager's comment says must never happen. Automerge widened it every time a checkov bump landed. The annotation-driven pattern now has its own manager with no template, and the gate is resynced by hand this once, verified passing locally.

## 3. Record the Jellyfin wiring flake

`test_jellyfin_connection_matches_what_the_app_supports[lidarr]` failed on two runs on 2026-08-18 and passed on retry both times, shortly after Jellyfin 10.11.10 merged unattended. The reason it is silent is `scripts/wire-connections.sh:1003`, where `ensure_jellyfin_connection` is called with `|| true`, so a failure leaves the app without the connection while `make wire_connections` still reports success. The Prowlarr path in the same file already collects failures instead of swallowing them, for the reason its own comment gives.

Recorded in `docs/TODO.md` rather than fixed here, since it needs its own investigation. It matters more than a normal flake now that updates merge unattended: an intermittent test means a bot PR stalls at random and waits for a person.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Checkov pre-commit hook to version 3.3.10.
  * Improved automated dependency update configuration, including support for additional pre-commit dependency pins.

* **Documentation**
  * Added a TODO documenting intermittent Jellyfin connection issues and the need for improved failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->