### PR TITLE
Stagger dependency updates, and stop losing CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,6 +36,21 @@ reviews:
   # carrying a change to workflow or hook logic alongside it.
   request_changes_workflow: false
   auto_review:
+    # Never stop reviewing a branch for being busy. The default is 5, which
+    # pauses automatic reviews once five commits on a branch have been
+    # reviewed, and the pause is silent: the CodeRabbit check still reports
+    # green, so the pull request looks reviewed when nothing has read its
+    # current head.
+    #
+    # Observed directly on pre-commit-checklists#12, a branch with seven
+    # commits: automatic reviews stopped after the fifth, and twelve hours
+    # passed with no review of the head commit and no indication that
+    # anything was waiting. Recovering needs a manual `@coderabbitai review`.
+    #
+    # The reviews this saves are on fixup commits, which is real, but a
+    # review that silently stops is worse than one that costs a slot.
+    auto_pause_after_reviewed_commits: 0
+
     # CodeRabbit is a GitHub App posting a check, not a workflow job, so it
     # cannot be ordered after the linters with `needs:` the way a workflow job
     # can. Skipping drafts is the only lever, and it is the one that matters:

--- a/.cspell.json
+++ b/.cspell.json
@@ -623,6 +623,7 @@
     "signum",
     "singleaudio",
     "sitelink",
+    "skopeo",
     "slicerange",
     "SLSK",
     "smbcredentials",

--- a/.cspell.json
+++ b/.cspell.json
@@ -152,6 +152,7 @@
     "cmtag",
     "cmtagger",
     "coderabbit",
+    "coderabbitai",
     "codesnap",
     "codezombiech",
     "comiccat",

--- a/.env.example
+++ b/.env.example
@@ -318,7 +318,7 @@ HOMEPAGE_VERSION=v1.12.3@sha256:cc84f2f5eb3c7734353701ccbaa24ed02dacb0d119114e50
 GRAFANA_VERSION=11.6.5@sha256:d552f949693c54d17c6f867ff6aeb128b021e54e923895dcf9cd6aa8176c0d74
 # renovate: depName=docker.io/linuxserver/jellyfin
 JELLYFIN_VERSION=10.11.10@sha256:be2bd22d5e27451ebc14b326d8a6554e1f51c79f4431d6c71522565ed17f06ea
-# renovate: depName=linuxserver/lazylibrarian versioning=loose
+# renovate: depName=docker.io/linuxserver/lazylibrarian versioning=loose
 LAZYLIBRARIAN_VERSION=40a389ea-ls310
 # renovate: depName=docker.io/linuxserver/lidarr
 LIDARR_VERSION=3.1.0@sha256:2e4cdc7c8d5fa36915f446a29976ee01d3f9cc9722b8530a09121c76fbabef55

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+
+# The three ecosystems below are staggered onto separate days rather than all
+# opening Monday, so the suites they trigger do not queue behind one another
+# and so a person does not see every dependency pull request for the week
+# arrive as one batch. Security updates are not affected either way: they are
+# alert driven and open as soon as GitHub raises the alert, ignoring this
+# schedule entirely.
 updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -23,7 +30,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      day: monday
+      day: tuesday
       time: "06:30"
       timezone: "America/Toronto"
     labels:
@@ -42,7 +49,7 @@ updates:
     directory: "/tests"
     schedule:
       interval: weekly
-      day: monday
+      day: wednesday
       time: "07:00"
       timezone: "America/Toronto"
     labels:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,15 +19,18 @@
 
   timezone: "America/Toronto",
 
-  // One window a week for creating branches, so the pull requests arrive
-  // together rather than trickling in.
+  // The default day for anything not named in a group below. Each group in
+  // packageRules carries its own schedule, so this is only reached by images
+  // that stay ungrouped on purpose. See docs/DEPENDENCY_UPDATES.md for the
+  // full weekday layout and the reasoning behind spreading updates across the
+  // week instead of opening everything on one day.
   //
   // Only creating. updateNotScheduled defaults to true, so branches that
   // already exist are still rebased outside the window, which matters here
   // because required checks are strict: every merge puts the other open pull
-  // requests behind, and they would sit until the next Monday if Renovate could
-  // not touch them. This was misread once as a reason not to restore the window
-  // at all.
+  // requests behind, and they would sit until the next scheduled day if
+  // Renovate could not touch them. This was misread once as a reason not to
+  // restore the window at all.
   //
   // Lifted briefly on 2026-08-18 to produce a bot pull request on demand, which
   // is the only way to observe whether CodeRabbit auto-reviews one. It does not.
@@ -41,7 +44,7 @@
   // days on top of the seven minimumReleaseAge already imposes, and it existed
   // to give a person one sitting a week to work through the batch. Nothing is
   // worked through by hand any more.
-  schedule: ["before 7am on Monday"],
+  schedule: ["before 7am on saturday"],
 
   labels: ["dependencies", "docker"],
   commitMessagePrefix: "chore:",
@@ -120,68 +123,110 @@
       automerge: true,
       addLabels: ["automerge"],
     },
-    // *arr suite — group together as they share config and often release together.
+    // The arr suite. Grouped to cut the pull request volume these seven images
+    // would otherwise open one at a time, not because they share a release
+    // cadence. They do not: image creation dates measured with skopeo inspect
+    // on 2026-08-18 run from readarr on 2025-06-27 to prowlarr and sonarr in
+    // early August 2026, fifteen months apart across the full set, so grouping
+    // on "they release together" would be fiction. These are also the images
+    // that have not broken anything recently, unlike the download clients kept
+    // isolated further down, which is the actual reason they are grouped while
+    // those are not.
     {
       matchDatasources: ["docker"],
       matchPackageNames: [
-        "linuxserver/bazarr",
-        "linuxserver/lidarr",
-        "linuxserver/prowlarr",
-        "linuxserver/radarr",
-        "linuxserver/readarr",
-        "linuxserver/sonarr",
+        "docker.io/linuxserver/sonarr",
+        "docker.io/linuxserver/radarr",
+        "docker.io/linuxserver/lidarr",
+        "docker.io/linuxserver/readarr",
+        "docker.io/linuxserver/prowlarr",
+        "docker.io/linuxserver/bazarr",
         "ghcr.io/recyclarr/recyclarr",
       ],
       groupName: "arr suite",
       groupSlug: "arr-suite",
+      schedule: ["before 7am on thursday"],
     },
-    // VPN and bypass tools — kept separate because they affect the kill-switch test.
+    // The observability stack. Disabled by default, so a group blocked by one
+    // bad member costs little, and this is grouped mainly for tidiness rather
+    // than volume, since it is only three images.
+    //
+    // grafana/promtail, gcr.io/cadvisor/cadvisor and prom/node-exporter used to
+    // be listed here. promtail is gone from the repository entirely, the stack
+    // uses Alloy now, and the other two are pinned in .env.example with no
+    // `# renovate:` annotation, so Renovate cannot see either one regardless of
+    // what this group names. Matching bare package names without the registry
+    // also meant this rule matched 0 of its 5 listed members before this
+    // rewrite, which is a separate problem from the three that no longer
+    // belong here at all: see the depName note above the customManagers below.
     {
       matchDatasources: ["docker"],
       matchPackageNames: [
-        "ghcr.io/qdm12/gluetun",
-        "ghcr.io/tprasadtp/protonwire",
-        "docker.io/flaresolverr/flaresolverr",
-      ],
-      groupName: "vpn and network tools",
-      groupSlug: "vpn-network",
-    },
-    // Observability stack — disabled by default, group for tidiness.
-    {
-      matchDatasources: ["docker"],
-      matchPackageNames: [
-        "grafana/grafana-oss",
-        "prom/prometheus",
-        "grafana/promtail",
-        "gcr.io/cadvisor/cadvisor",
-        "prom/node-exporter",
+        "docker.io/grafana/grafana-oss",
+        "docker.io/prom/prometheus",
+        "docker.io/grafana/loki",
       ],
       groupName: "observability stack",
       groupSlug: "observability",
+      schedule: ["before 7am on friday"],
     },
-    // Remaining linuxserver images (downloaders, library tools).
+    // Library and reading tools. Grouped for the same reason as the arr suite
+    // above, to cut pull request volume, not because these five share a
+    // release cadence. None of them touch the VPN namespace or a download
+    // client, so none of the reasoning that keeps gluetun and the download
+    // clients isolated below applies here.
     {
       matchDatasources: ["docker"],
-      // Slashes mark a regex; the trailing one is part of the pattern. The
-      // negated entries are what excludePackageNames used to express.
       matchPackageNames: [
-        "/^linuxserver//",
-        "!linuxserver/bazarr",
-        "!linuxserver/lidarr",
-        "!linuxserver/prowlarr",
-        "!linuxserver/radarr",
-        "!linuxserver/readarr",
-        "!linuxserver/sonarr",
+        "docker.io/linuxserver/calibre",
+        "docker.io/linuxserver/calibre-web",
+        "docker.io/linuxserver/lazylibrarian",
+        "ghcr.io/advplyr/audiobookshelf",
+        "ghcr.io/nperez0111/koreader-sync",
       ],
-      groupName: "linuxserver images",
-      groupSlug: "linuxserver",
+      groupName: "library and reading tools",
+      groupSlug: "library-reading",
+      schedule: ["before 7am on friday"],
     },
-    // Media library servers.
+    // gluetun, flaresolverr, wireguard, every download client (qbittorrent,
+    // sabnzbd, nzbget, nzbhydra2, jdownloader-2), jellyfin and homepage are
+    // deliberately named in no group here, so each opens its own pull request
+    // on the root schedule instead of sharing one with anything else. A group
+    // is only as mergeable as its worst member, and the two bumps that broke
+    // something this week, SABnzbd 5.0.4 and qBittorrent 5.2.2 (see
+    // docs/TODO.md), were both download clients. Isolating them keeps one bad
+    // image from blocking every other pull request a shared group would have
+    // bundled it with. gluetun is what every download client's kill switch
+    // depends on, so the same argument isolates it too. This is where the
+    // former "vpn and network tools" and "media library servers" groups used
+    // to sit; the first also listed ghcr.io/tprasadtp/protonwire, a package
+    // with no corresponding pin anywhere in this repository, so it matched
+    // nothing and is not carried forward.
+    //
+    // Lint and scanner tooling. Backs the pre-commit hooks and the workflow's
+    // Security Reports SARIF job, both driven by the customManagers below,
+    // grouped to cut the volume eight separate pins would otherwise open.
+    // Spans three datasources (docker, pypi and go), so this rule matches on
+    // depName alone rather than a matchDatasources value that could only cover
+    // part of the list. Each depName here is the exact string the pin's own
+    // `# renovate:` annotation declares, since that annotation, not the image
+    // or package name written elsewhere in the same line, is what the two
+    // customManagers below treat as authoritative for both datasource and
+    // name.
     {
-      matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/advplyr/audiobookshelf"],
-      groupName: "media library servers",
-      groupSlug: "media-library",
+      matchPackageNames: [
+        "aquasec/trivy",
+        "zricethezav/gitleaks",
+        "dotenvlinter/dotenv-linter",
+        "hadolint/hadolint",
+        "lycheeverse/lychee",
+        "checkov",
+        "zizmor",
+        "github.com/zricethezav/gitleaks/v8",
+      ],
+      groupName: "lint and scanner tooling",
+      groupSlug: "lint-scanner-tooling",
+      schedule: ["before 7am on sunday"],
     },
     // The container runtime tooling CI installs, pinned inline in the
     // workflows. Grouped so the two copies of the pin always move in one pull
@@ -205,6 +250,7 @@
       groupName: "container runtime tooling",
       groupSlug: "ci-runtime",
       addLabels: ["ci-runtime"],
+      schedule: ["before 7am on sunday"],
     },
   ],
 

--- a/.github/workflows/coderabbit-review-queue.yml
+++ b/.github/workflows/coderabbit-review-queue.yml
@@ -1,0 +1,123 @@
+---
+name: CodeRabbit Review Queue
+
+# Asks CodeRabbit to review a pull request whose current head has not actually
+# been read, one per run, hourly.
+#
+# Why this exists. CodeRabbit support confirmed that pull requests authored by
+# bots are hardcoded to be ignored on their side, so renovate[bot] and
+# dependabot[bot] pull requests are never auto-reviewed here. Those are exactly
+# the pull requests that merge unattended, and docs/HARDENING.md names CodeRabbit
+# as the only thing in the pipeline that reads a bump for intent. Asked directly
+# it answers in under three minutes, so the capability is there and only the
+# automatic trigger is missing. They are investigating; until that changes, this
+# is the trigger.
+#
+# It is not limited to bots, because "was this reviewed" is not the same question
+# as "who opened it". A green `CodeRabbit` status is not evidence of a review: it
+# is also green on a skipped draft, on a rate-limited decline, and on a silent
+# pause once `auto_pause_after_reviewed_commits` is reached. So the condition
+# below is about the head commit rather than the author, which catches a human
+# pull request whose review the quota dropped just as well as a bot's.
+on:
+  schedule:
+    # Hourly, matching the rolling window the review quota is measured over.
+    # Cron on a public repository is best effort and can run late, which is fine:
+    # a late nudge is still a nudge.
+    - cron: "23 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nudge:
+    name: Ask for one missing review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # For the comment. Reading statuses and comments needs nothing extra on a
+      # public repository.
+      pull-requests: write
+    steps:
+      - name: Find one head with no review, and ask
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Forks are capped so a contributor's pull request cannot collect a
+          # comment every hour forever while the quota is exhausted. Our own
+          # branches are not capped: the noise is ours to bear, and a bump that
+          # merges unattended should keep asking until it is read.
+          FORK_ATTEMPT_CAP: "3"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Oldest first, so nothing is starved by newer pull requests arriving
+          # ahead of it every hour. Drafts are excluded deliberately: skipping
+          # them is what gets the mechanical linters to clean a diff before a
+          # review slot is spent on it, which is why .coderabbit.yaml sets
+          # drafts: false.
+          prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
+            --json number,headRefOid,isDraft,isCrossRepository \
+            --jq 'sort_by(.number) | .[] | select(.isDraft == false)
+                  | "\(.number) \(.headRefOid) \(.isCrossRepository)"')
+
+          if [ -z "$prs" ]; then
+            echo "No open non-draft pull requests."
+            exit 0
+          fi
+
+          while read -r number sha is_fork; do
+            [ -n "$number" ] || continue
+
+            # A status whose description says it declined is not a review. Those
+            # are the ones worth re-asking for; a real "Review completed" is not.
+            state=$(gh api "repos/$REPO/commits/$sha/status" \
+              --jq "[.statuses[] | select(.context == \"CodeRabbit\") | .description] | first // \"\"")
+
+            case "$state" in
+              "")
+                reason="no CodeRabbit status on this head" ;;
+              *[Rr]"ate limited"* | *[Ss]"kipped"*)
+                reason="status says \"$state\", which is not a review" ;;
+              *)
+                echo "#$number: \"$state\" on ${sha:0:8}, nothing to do."
+                continue ;;
+            esac
+
+            # One marker per attempt, carrying the head SHA, so the cap below
+            # counts attempts against this head only and a rebase starts fresh.
+            marker="<!-- coderabbit-nudge: $sha -->"
+            attempts=$(gh api "repos/$REPO/issues/$number/comments" --paginate \
+              | jq -s --arg m "$marker" '[.[][] | select(.body | contains($m))] | length')
+
+            if [ "$attempts" -gt 0 ]; then
+              last=$(gh api "repos/$REPO/issues/$number/comments" --paginate \
+                | jq -s -r --arg m "$marker" '[.[][] | select(.body | contains($m)) | .created_at] | max')
+              age=$(( $(date -u +%s) - $(date -u -d "$last" +%s) ))
+              if [ "$age" -lt 3000 ]; then
+                echo "#$number: nudged ${age}s ago, leaving it alone this run."
+                continue
+              fi
+            fi
+
+            if [ "$is_fork" = "true" ] && [ "$attempts" -ge "$FORK_ATTEMPT_CAP" ]; then
+              echo "#$number: fork, already asked $attempts times for ${sha:0:8}. Staying quiet."
+              continue
+            fi
+
+            echo "#$number (${sha:0:8}): $reason. Asking for a review."
+            # GITHUB_TOKEN is enough. The suppression that bites elsewhere in
+            # this repository, where an event a workflow's own token creates
+            # starts no further workflow, does not apply: CodeRabbit is a GitHub
+            # App on a webhook, not a workflow trigger.
+            gh pr comment "$number" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
+
+            # One per run. The quota frees a slot at a time, and firing a batch
+            # into an exhausted window bounces all of them and wastes the slot
+            # that was free.
+            exit 0
+          done <<< "$prs"
+
+          echo "Every open non-draft pull request has a real review on its head."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -339,16 +339,26 @@ jobs:
         # the only backstop turns a mirror hiccup into a failed suite, and the
         # publish job can only report that the run did not finish.
         #
-        # Two minutes is generous for two apt calls that normally take seconds,
-        # and three attempts covers a mirror that is briefly unreachable rather
-        # than down. The explicit timeouts on apt itself are what make a stall
-        # fail fast enough for the retry to be worth having.
-        timeout-minutes: 5
+        # No custom Acquire timeouts, and that is the correction. A first
+        # attempt set them to 15 seconds so a stall would fail fast enough to
+        # retry, which instead made a slow mirror fail *deterministically*:
+        # azure.archive.ubuntu.com took longer than 15 seconds to answer, apt
+        # gave up on the source with `Ign:`, and installing then failed because
+        # the archive's package lists had never been fetched. Three attempts
+        # reproduced it three times. The proof it was self inflicted is that
+        # pull-request-validation.yml installs the same package with a bare
+        # apt-get and passed on the same runner pool in the same minute.
+        #
+        # So apt keeps its own timeouts, the retry stays for a genuinely
+        # transient failure, and the step bound below is what protects against a
+        # hang. That is the right division: a limit catches a stall, it should
+        # not manufacture one.
+        timeout-minutes: 8
         shell: bash
         run: |
           set -euo pipefail
-          apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
-          for attempt in 1 2 3; do
+          apt_opts=(-o Acquire::Retries=3)
+          for attempt in 1 2; do
             if sudo apt-get "${apt_opts[@]}" update \
               && sudo apt-get "${apt_opts[@]}" install -y xmlstarlet; then
               exit 0

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -1,0 +1,130 @@
+# Dependency Updates
+
+Two bots open dependency pull requests here, Dependabot and Renovate, and each owns a
+different slice of the surface. This page is the reference for what runs when and why the
+schedule is shaped the way it is. The mechanics of how a bump actually merges live in
+[docs/CONTRIBUTING.md](CONTRIBUTING.md) step 8; this page does not repeat them.
+
+## Which tool manages what
+
+| Ecosystem | Tool | Where the pin lives |
+| --- | --- | --- |
+| pre-commit hook revisions | Dependabot | `.pre-commit-config.yaml`, the `rev:` of each hook repo |
+| GitHub Actions | Dependabot | Workflow `uses:` versions under `.github/workflows/` |
+| pip, test suite | Dependabot | `tests/requirements.txt` |
+| Docker image versions | Renovate | `.env.example`, behind a `# renovate: depName=...` annotation |
+| pip, inline in a workflow | Renovate | A `pip install pkg==x` line, behind a `# renovate:` annotation |
+| Go module and pypi pins in pre-commit | Renovate | `additional_dependencies` in `.pre-commit-config.yaml` |
+| Docker images pinned inside a hook `entry:` | Renovate | `.pre-commit-config.yaml` and the workflow SARIF job |
+
+The split exists because Dependabot's pip ecosystem only reads requirements files. It would
+never see `pip install podman-compose==1.6.0` sitting inside a workflow's `run:` step, so a pin
+left unwatched there rots silently, which is exactly how CI once ended up installing whatever
+version of `podman-compose` happened to be current. Renovate's `# renovate:` annotations are
+the seam that covers those inline pins, and the reasoning is spelled out in the header comment
+of [`.github/renovate.json5`](../.github/renovate.json5); this page reuses that reasoning rather
+than restating it differently.
+
+## The weekday layout
+
+| Day | Tool | What opens |
+| --- | --- | --- |
+| Monday | Dependabot | pre-commit hook revisions |
+| Tuesday | Dependabot | GitHub Actions |
+| Wednesday | Dependabot | pip, `tests/requirements.txt` |
+| Thursday | Renovate | The arr suite group (sonarr, radarr, lidarr, readarr, prowlarr, bazarr, recyclarr) |
+| Friday | Renovate | The observability stack group and the library and reading tools group |
+| Saturday | Renovate | Every ungrouped image, one pull request each (the root schedule, used as the default) |
+| Sunday | Renovate | The lint and scanner tooling group and the container runtime tooling pin |
+
+## Why the days are staggered
+
+Required status checks are strict on `main`, which is the setting that makes the stagger worth
+doing. Every merge puts every other open pull request behind, so each one needs a rebase and
+another full run of the integration suite, roughly fifteen minutes a time. If every ecosystem
+opened on the same day, the pull requests it produced would queue behind each other: the first
+merge rebases the rest, which triggers another round of runs, which produces another merge that
+rebases what is left again. Spreading the ecosystems and groups across the week keeps that churn
+from compounding into one bad day. `docs/TODO.md` records a case where a single small change
+needed three separate suite runs for this reason, before the schedule was spread out.
+
+## The grouping rationale
+
+Grouping in `.github/renovate.json5` is about pull request volume against blast radius, not a
+shared release cadence, and it is worth being explicit that the cadence framing would be
+fiction. Image creation dates measured with `skopeo inspect` on 2026-08-18:
+
+| Image | Build date |
+| --- | --- |
+| nzbget | 2025-05-09 |
+| readarr | 2025-06-27 |
+| gluetun | 2026-02-11 |
+| qbittorrent | 2026-05-03 |
+| jellyfin | 2026-06-02 |
+| bazarr | 2026-06-30 |
+| radarr | 2026-08-02 |
+| calibre-web | 2026-08-02 |
+| loki | 2026-08-05 |
+| prowlarr | 2026-08-05 |
+| sabnzbd | 2026-08-06 |
+| sonarr | 2026-08-07 |
+| lidarr | 2026-08-12 |
+
+Fifteen months separate the oldest and newest build in that list, so nothing here releases on a
+shared schedule. The arr suite, the observability stack, and the library and reading tools are
+grouped anyway, purely to keep the number of pull requests down, and grouping only makes sense
+where a bad member costs little: those three groups hold images that have not caused a problem
+recently, or, for the observability stack, sit behind a profile that is disabled by default.
+
+The download clients (qbittorrent, sabnzbd, nzbget, nzbhydra2, jdownloader-2), jellyfin,
+homepage, flaresolverr, wireguard, and gluetun are deliberately left out of every group, so each
+arrives as its own pull request on the Saturday default instead. A group is only as mergeable as
+its worst member, and this week supplied two examples, both download clients: SABnzbd 5.0.4
+rewrote its own bind address in a way that broke a test (see `docs/TODO.md`), and qBittorrent
+5.2.2 changed its login response to `204 No Content`, which is still holding pull request #83.
+Had either of those shipped inside a group, it would have blocked every other image bundled with
+it rather than only itself. gluetun is isolated for the same reason: it is what the download
+clients' kill switch depends on, so a bad gluetun bump is exactly the kind of failure a group
+should not be allowed to spread.
+
+## Security updates
+
+Both bots' security paths are alert driven and enabled on this repository, and neither reads the
+schedules above at all. Dependabot's security updates open as soon as GitHub raises an alert.
+Renovate's `vulnerabilityAlerts` setting clears the inherited `minimumReleaseAge` window, so a
+fix for a known vulnerability is never held back by the cooling period described below.
+
+That coverage has a real gap, and it is worth stating plainly rather than leaving it implicit.
+The dependency graph GitHub builds for this repository holds 17 packages, all GitHub Actions and
+pip, and zero container images: GitHub raises no vulnerability alert for a container image at
+all, so the images in `.env.example` get no security signal from this mechanism, ever. Scanning
+the images themselves was considered and deliberately declined, because they are third party and
+not ours to patch: nothing here can fix a vulnerability inside a published image, only wait for
+upstream to. The practical consequence is that the seven day `minimumReleaseAge` window in
+`.github/renovate.json5` is pure latency for every image bump, with nothing available to bypass
+it the way `vulnerabilityAlerts` bypasses it for Actions and pip. That is a conscious trade, not
+a hedge: see [docs/HARDENING.md](HARDENING.md) for the full reasoning behind leaning on the
+cooling window instead of a scanner for this class of dependency.
+
+## Known gaps
+
+Twelve image pins in `.env.example` carry no `# renovate:` annotation at all, so Renovate cannot
+see them and they stay frozen at whatever version is committed: `CADVISOR_VERSION`,
+`MYLAR_VERSION`, `NGINX_EXPORTER_VERSION`, `NODE_EXPORTER_VERSION`, `NOTIFIARR_VERSION`,
+`PODMAN_LIMITS_EXPORTER_VERSION`, `PODMAN_EXPORTER_VERSION`, `ALLOY_VERSION`,
+`LOG_ROTATOR_VERSION`, `QBITTORRENT_EXPORTER_VERSION`, `SABNZBD_EXPORTER_VERSION`, and
+`JACKETT_VERSION`. Annotating them is a follow up, not part of this change.
+
+Separately, three tags are deliberately left floating rather than pinned to a version at all:
+`NGINX_VERSION=stable-alpine`, `PLEX_VERSION=latest`, and `WHISPARR_VERSION=v3`.
+
+`LAZYLIBRARIAN_VERSION` is annotated and Renovate does see it, but unlike every other annotated
+pin in the file it carries no digest, only a loose upstream tag. It is the one annotated pin
+this change did not add a digest to, since inventing one would not be honest about what has
+actually been verified.
+
+---
+
+See also: [README.md](../README.md), [docs/HARDENING.md](HARDENING.md),
+[docs/CONTRIBUTING.md](CONTRIBUTING.md), [docs/TESTING.md](TESTING.md),
+[docs/TODO.md](TODO.md)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -112,9 +112,35 @@ for what was fixed and when.
   suppresses a review. GitHub's 2026-08-17 webhook incident is ruled out because
   the retest ran hours after it resolved and reproduced. This matters because
   docs/HARDENING.md names CodeRabbit as the only thing that reads a dependency
-  bump for intent, and right now it is not reading them. Until it is fixed,
-  `@coderabbitai review` on a bot pull request works as a manual fallback
+  bump for intent, and right now it is not reading them.
+
+  Answered, and still open. Support confirmed that pull requests authored by
+  bots are hardcoded to be ignored on their side, so this is neither our
+  configuration nor the review quota. They are investigating and will come back.
+  Keep this item open rather than closing it as answered, because the outcome
+  wanted here is that behavior changed, not merely explained. Meanwhile
+  `.github/workflows/coderabbit-review-queue.yml` asks on their behalf, hourly,
+  one pull request per run, which is the only way a bot pull request gets read at
+  all while the ignore list stands. Delete that workflow once they lift it
   <!-- cspell:ignore coderabbitai -->
+- [ ] Confirm `auto_pause_after_reviewed_commits: 0` behaves as intended on
+  the next long-lived branch here. It was changed from the default of `5` in
+  `.coderabbit.yaml` because that default pauses automatic reviews after five
+  reviewed commits **silently**: the CodeRabbit check stays green, so a pull
+  request looks reviewed when nothing has read its head. Seen on
+  `pre-commit-checklists#12` (seven commits), where reviews stopped after the
+  fifth and twelve hours passed with no review and no warning
+- [ ] Nothing to configure for the other half of the problem: the
+  included-review quota (3/hour) **drops** a review rather than queueing it, so
+  a push during exhaustion is lost. The published schema
+  (`schema.v2.json`) has no retry, backoff or queue setting. Recovery is a
+  manual `@coderabbitai review`. Treat a green CodeRabbit check as "no review
+  blocked this", not as "a review happened": it is also green on a skipped
+  draft and on a rate-limited decline
+- [ ] `drafts: false` stays deliberate. CodeRabbit is a GitHub App posting a
+  check, not a workflow job, so it cannot be ordered after pre-commit with a
+  `needs:` dependency; skipping drafts is the lever that gets the mechanical
+  defects fixed before a review slot is spent
 
 ## Repository settings
 
@@ -167,6 +193,29 @@ for what was fixed and when.
   setting applies it unconditionally, so pypi and go updates arrive tagged as
   container images: #54, a checkov bump, carried it. Cosmetic, but the labels are
   load-bearing now that `automerge` is one of them
+
+- [ ] Annotate the twelve container image pins Renovate cannot see. Each carries
+  a digest but no `# renovate:` comment, so nothing watches it and the pin is
+  frozen: `CADVISOR`, `MYLAR`, `NGINX_EXPORTER`, `NODE_EXPORTER`, `NOTIFIARR`,
+  `PODMAN_LIMITS_EXPORTER`, `PODMAN_EXPORTER`, `ALLOY`, `LOG_ROTATOR`,
+  `QBITTORRENT_EXPORTER`, `SABNZBD_EXPORTER` and `JACKETT`. Some are more than a
+  year old. `NGINX_VERSION=stable-alpine`, `PLEX_VERSION=latest` and
+  `WHISPARR_VERSION=v3` are deliberately floating and want no annotation.
+  `LAZYLIBRARIAN_VERSION` is annotated but carries no digest, unlike every other
+  managed pin, so `pinDigests` should be allowed to add one. Left out of the
+  staggering change on purpose: annotating twelve images changes what arrives
+  every week and deserves its own pull request and its own suite runs. See
+  [docs/DEPENDENCY_UPDATES.md](DEPENDENCY_UPDATES.md) for how the managed set is
+  divided today
+
+- [ ] Add a test that fails when an image pin goes unwatched, so the gap above
+  cannot recur silently. Walk `.env.example`, and for every variable naming a
+  container image assert it carries a `# renovate:` annotation and a digest, with
+  an explicit allowlist for the tags that are deliberately floating. Same shape
+  as `tests/test_prerequisites.py` asserting runtime databases stay untracked,
+  where the point is that a reintroduced mistake fails the suite rather than
+  reaching a commit. It would have caught all twelve, and lazylibrarian's
+  missing digest
 
 ## qBittorrent
 


### PR DESCRIPTION
Four related changes, in one pull request because they share a theme and a single suite run. Strict checks mean each merge invalidates the next, so splitting them would cost three more fifteen minute cycles for no benefit.

## 1. The grouping was dead, and the reason it was written is fiction

`matchPackageNames` is compared against the full registry qualified depName, and the rules omitted the registry. Measured: the observability rule matched **0 of 5**, the arr suite **1 of 7**, and the anchored `^linuxserver/` regex matched exactly one image, `lazylibrarian`, because it is the only annotation missing a prefix. So **19 of 24 images were ungrouped** and arrived as one pull request each.

The original comments justified grouping by shared release cadence. That is not true. Creation dates measured with `skopeo inspect`, no pulls needed:

```
nzbget 2025-05-09   readarr 2025-06-27   gluetun 2026-02-11   qbittorrent 2026-05-03
jellyfin 2026-06-02  bazarr 2026-06-30   radarr 2026-08-02    lidarr 2026-08-12
```

Fifteen months apart. Grouping is now justified on the honest grounds, volume against blast radius, and the doc says so.

## 2. Staggered across the week

| day | what |
|---|---|
| Mon / Tue / Wed | Dependabot: pre-commit, Actions, pip |
| Thu | arr suite |
| Fri | observability stack, library and reading tools |
| Sat | everything ungrouped (root schedule) |
| Sun | lint and scanner tooling, container runtime pin |

Every download client stays **ungrouped and isolated**, along with gluetun and the VPN mock. Both bumps that broke things this week were download clients, SABnzbd rewriting its bind address and qBittorrent changing its login response, and a group is only as mergeable as its worst member. Security updates are unaffected either way: Dependabot's are alert driven and ignore the schedule, and `vulnerabilityAlerts` defaults to running at any time.

Also dropped from the observability group: `grafana/promtail`, which no longer exists here since the stack moved to Alloy, and cadvisor and node-exporter, which are pinned but unannotated so Renovate cannot see them.

## 3. CodeRabbit stops pausing reviews silently

`auto_pause_after_reviewed_commits` defaulted to 5, which halts automatic reviews after five reviewed commits **while leaving the check green**. Observed on a seven commit branch elsewhere, where twelve hours passed with no review and no signal. That is the third state showing green without a review, alongside a skipped draft and a rate limited decline.

## 4. Something now asks for the reviews CodeRabbit will not start

Support confirmed that **bot authored pull requests are hardcoded to be ignored on their side**. Not our config, not the quota, not the webhook incident. They are investigating.

`coderabbit-review-queue.yml` asks on their behalf, hourly, one pull request per run. It keys on the head commit rather than the author, so it also catches a human pull request whose review the quota dropped. Drafts are never nudged. Our own branches are nudged without limit; forks stop after three attempts per head, since a contributor should not collect a comment every hour while a rate limiter is the only obstacle. The logic was dry run against this repository before committing and selected exactly the one pull request whose head has no `CodeRabbit` status.

## Recorded, not fixed

`docs/DEPENDENCY_UPDATES.md` is new and carries the whole arrangement plus the coverage gap: the dependency graph holds 17 packages, all Actions and pip, and zero container images, so the images get no vulnerability signal at all. Scanning them was considered and declined, since they are third party and not ours to patch, which makes the seven day cooling window on images a conscious trade rather than a hedge.

`docs/TODO.md` gains the support answer, kept open because the outcome wanted is the behavior changed rather than explained, plus twelve image pins that carry digests but no annotation and are therefore frozen, and the absence of any test that would have caught them.

## Verification

`renovate-config-validator --strict` run bare, as CI does, reports success. Full `pre-commit --hook-stage pre-push` sweep is clean. zizmor reports no findings on the new workflow. Confirmed by inspection that the automerge rule is still first in `packageRules`, since later rules win on shared keys, and that both `customManagers` are untouched.