### PR TITLE
Surface Renovate's warnings, and stop mislabelling non-image updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,10 +12,15 @@
   // podman-compose happened to be current.
   extends: ["config:recommended"],
 
-  // config:recommended enables a standing "Dependency Dashboard" issue that
-  // never resolves on its own; PRs still open on the normal schedule below
-  // without it, this just drops the one consolidated overview issue.
-  dependencyDashboard: false,
+  // Kept on for its warnings, not for the overview of pending updates. Two
+  // lookup failures sat unseen on Mend's hosted dashboard for weeks: nothing
+  // in this repository surfaces them, and during that stretch the checkov pin
+  // in .pre-commit-config.yaml silently stopped updating, drifting three
+  // patch versions behind the copy in the workflow. Renovate Config cannot
+  // catch that class of problem, because the config is valid, it just does
+  // the wrong thing; an issue here would have shown it. The cost is one
+  // standing issue that never closes on its own, taken deliberately.
+  dependencyDashboard: true,
 
   timezone: "America/Toronto",
 
@@ -46,7 +51,12 @@
   // worked through by hand any more.
   schedule: ["before 7am on saturday"],
 
-  labels: ["dependencies", "docker"],
+  // `docker` is not here on purpose. It is added by the datasource rule in
+  // packageRules below, so a pypi or go update no longer arrives tagged as a
+  // container image: #54, #64, #67 and #70 all carried it wrongly. The labels
+  // are load bearing now that bot-auto-merge.yml keys on `automerge`, so one
+  // that says the wrong thing is worth correcting rather than tolerating.
+  labels: ["dependencies"],
   commitMessagePrefix: "chore:",
 
   // Keep PR volume manageable so CI is not overwhelmed.
@@ -122,6 +132,19 @@
       matchUpdateTypes: ["patch", "minor", "digest", "pin", "pinDigest"],
       automerge: true,
       addLabels: ["automerge"],
+    },
+    // The `docker` label, applied by datasource instead of to everything. It
+    // used to live in the root `labels` above, so every pypi and go update
+    // arrived tagged as a container image. This covers both customManagers
+    // that set `datasourceTemplate: "docker"`, and correctly leaves out the
+    // ones taking their datasource from the annotation, which is how checkov,
+    // zizmor, podman-compose and gitleaks stop being called images.
+    //
+    // addLabels accumulates rather than replacing, so this composes with the
+    // rule above and with the group rules below instead of racing them.
+    {
+      matchDatasources: ["docker"],
+      addLabels: ["docker"],
     },
     // The arr suite. Grouped to cut the pull request volume these seven images
     // would otherwise open one at a time, not because they share a release

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -144,17 +144,6 @@ for what was fixed and when.
 
 ## Repository settings
 
-- [ ] Change Actions' default workflow permissions from write to read
-  (Settings, Actions, General, Workflow permissions). Verified still `write` via
-  `gh api repos/ivan-pinatti/docker-torrent-box-with-vpn/actions/permissions/workflow`.
-  Every workflow in this repository already declares its own `permissions:`
-  block, so nothing needs the permissive default today. It matters more than it
-  used to: since code owner review came off `main`, a single approving review is
-  enough to merge, and any future workflow that forgets a `permissions:` block
-  would hold a token able to approve pull requests and push. Leave
-  `can_approve_pull_request_reviews` enabled, since bot-auto-merge.yml depends
-  on it
-
 - [ ] Narrow `DOCKERHUB_TOKEN` to public read only. The integration suite
   authenticates to Docker Hub and then runs whatever image a dependency bump
   just introduced, in the same job, and those merges are now unattended. The
@@ -176,23 +165,6 @@ for what was fixed and when.
   Renovate, so check that before choosing
 
 ## Renovate
-
-- [ ] Enable `dependencyDashboard` in `.github/renovate.json5`, and rewrite the
-  comment above it that argues for leaving it off. That comment weighed a
-  standing issue that never resolves against the noise, and missed the thing the
-  dashboard is actually for: warnings. Two lookup failures sat on Mend's hosted
-  dashboard for weeks, unseen because nothing in this repository surfaces it,
-  while the checkov pin in `.pre-commit-config.yaml` silently stopped updating
-  and drifted three patch versions behind the copy in the workflow. The
-  `Renovate Config` job cannot catch that class of problem, because the config
-  is valid, it just does the wrong thing. An issue in this repository would have
-  shown it. The dashboard issue Renovate opened before the setting was turned
-  off is #24, now closed
-
-- [ ] Stop labelling every Renovate pull request `docker`. The root `labels`
-  setting applies it unconditionally, so pypi and go updates arrive tagged as
-  container images: #54, a checkov bump, carried it. Cosmetic, but the labels are
-  load-bearing now that `automerge` is one of them
 
 - [ ] Annotate the twelve container image pins Renovate cannot see. Each carries
   a digest but no `# renovate:` comment, so nothing watches it and the pin is


### PR DESCRIPTION
Two Renovate config corrections, both open items in `docs/TODO.md` until now.

## `dependencyDashboard` back on

It was disabled for the standing issue it opens, which weighed the wrong thing. The dashboard is where Renovate reports **lookup warnings**, and two of those sat unseen on Mend's hosted dashboard for weeks. During that stretch the checkov pin in `.pre-commit-config.yaml` silently stopped updating and drifted three patch versions behind the copy in the workflow.

The `Renovate Config` job cannot catch that class of problem, because the config is valid, it just does the wrong thing. An issue in this repository would have shown it.

Note this opens a *fresh* dashboard issue rather than reopening #24.

## `docker` label applied by datasource

The root `labels` setting applied `docker` unconditionally, so every pypi and go update arrived tagged as a container image. Not only #54 as the todo recorded:

| PR | Update | Datasource |
| --- | --- | --- |
| #54, #64 | checkov | pypi |
| #66 | podman-compose | pypi |
| #67 | pre-commit | pypi |
| #70 | zizmor | pypi |

The label moves to a rule matching `matchDatasources: ["docker"]`, which covers both customManagers setting `datasourceTemplate: "docker"` and correctly excludes the ones taking their datasource from the annotation. `addLabels` accumulates rather than replacing, so it composes with the automerge rule above it and the group rules below.

Cosmetic on its face, but the labels are load bearing now that `bot-auto-merge.yml` keys on `automerge`.

## Also

Drops the Actions default workflow permissions item from `docs/TODO.md`. That one is a repository setting rather than a code change, and is already applied: `default_workflow_permissions` is now `read`, with `can_approve_pull_request_reviews` left enabled because `bot-auto-merge.yml` depends on it. Every workflow here declares its own `permissions:` block, so nothing relied on the permissive default.

## Validation

- `npx --package renovate@42.99.0 renovate-config-validator --strict`, the same command the `Renovate Config` job runs: config validated successfully.
- `markdownlint-cli2` at the pinned `v0.23.2` on `docs/TODO.md`: 0 issues.
- All pre-commit and pre-push hooks passed locally, including `gitleaks-history`, `trivy`, `checkov` and `lychee`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated dependency update tracking with a centralized dashboard.
  - Docker-related dependency updates now receive more accurate labels, while other updates retain general dependency labeling.

- **Documentation**
  - Removed completed repository-maintenance items from the project task list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->