### PR TITLE
Stop swallowing a Jellyfin wiring failure, and accept qBittorrent 5.2.2's login response

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -131,12 +131,44 @@ for what was fixed and when.
   `pre-commit-checklists#12` (seven commits), where reviews stopped after the
   fifth and twelve hours passed with no review and no warning
 - [ ] Nothing to configure for the other half of the problem: the
-  included-review quota (3/hour) **drops** a review rather than queueing it, so
-  a push during exhaustion is lost. The published schema
-  (`schema.v2.json`) has no retry, backoff or queue setting. Recovery is a
-  manual `@coderabbitai review`. Treat a green CodeRabbit check as "no review
-  blocked this", not as "a review happened": it is also green on a skipped
-  draft and on a rate-limited decline
+  included-review quota **drops** a review rather than queueing it, so a push
+  during exhaustion is lost. The published schema (`schema.v2.json`) has no
+  retry, backoff or queue setting. Recovery is a manual `@coderabbitai review`.
+  Treat a green CodeRabbit check as "no review blocked this", not as "a review
+  happened": it is also green on a skipped draft and on a rate-limited decline,
+  which is the item below
+- [ ] Stop a rate limited decline reporting green, which is how three pull
+  requests merged with no review on 2026-08-19. CodeRabbit reports through the
+  legacy commit status API rather than check runs, and that API offers only
+  `error`, `failure`, `pending` and `success`, with no `neutral`. An exhausted
+  quota resolves the status to `success` with the description
+  `Review rate limited`, which neither branch protection nor anything else
+  reading the status can tell apart from `success` with `Review completed`.
+  #86, #87 and #88 all ended there and all merged, and none of their status
+  histories carries a `Review completed` entry, while #82, #85 and #90 do. #87
+  is titled "Stagger dependency updates, and stop losing CodeRabbit reviews"
+  and was itself never read. The quota figure is also unclear: the review on
+  #90 reported "up to 10 included reviews per hour; 5 remain", not the 3 per
+  hour previously recorded here.
+
+  Raised as a follow-up on the existing support ticket, framed as one value
+  meaning two opposite things rather than as the wrong state being chosen. The
+  deadlock argument against holding `pending` forever is defensible, and a
+  status that cannot tell the two apart is not, so that framing is the one that
+  cannot be closed as intended behavior. `reviews.fail_commit_status` is the only related
+  setting and does not cover this: it acts on review errors, not on declines.
+
+  The fix that does not depend on them is a gate job asserting the description
+  equals `Review completed`, in the same shape as `Integration Tests` gating
+  `Integration Suite`. It has to special case bot pull requests, which get no
+  status at all, because a required context that is absent blocks a merge
+  indefinitely and would freeze every Renovate pull request. For the same
+  reason, do not simply mark the `CodeRabbit` context required: it would cause
+  that freeze while still passing every rate limited human pull request.
+  `required_conversation_resolution` is already enabled on `main`, so the
+  "every thread addressed" half is enforced today and only "a review happened"
+  is missing
+
 - [ ] `drafts: false` stays deliberate. CodeRabbit is a GitHub App posting a
   check, not a workflow job, so it cannot be ordered after pre-commit with a
   `needs:` dependency; skipping drafts is the lever that gets the mechanical

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -228,27 +228,6 @@ for what was fixed and when.
   reaching a commit. It would have caught all twelve, and lazylibrarian's
   missing digest
 
-## qBittorrent
-
-- [ ] Decide what the 5.1.4 to 5.2.2 bump means for `tests/test_auth.py`, and
-  unblock #83. Both `test_qbittorrent_api_login` and
-  `test_qbittorrent_web_session_login` assert `status_code == 200` and a body of
-  `Ok.`, and 5.2.2 answers with `204 No Content`, so both assertions fail and
-  the pull request is correctly red. The suite caught it, which is the system
-  working, and the bump has not merged.
-
-  What is not yet known is whether authentication still succeeds. A 204 with no
-  body could be the same successful login reported differently, or it could be a
-  login that is no longer working, and the tests fail at the status assertion
-  before reaching anything that would tell them apart. Check whether the
-  response still carries the `SID` cookie. If it does, keep a status assertion and
-  add the cookie: accept any successful 2xx and require a non-empty `SID`,
-  dropping only the exact `200` and the `Ok.` body, which are the two parts
-  upstream is free to change. Do not swap the status check out for a cookie check
-  alone, or an error response that happens to set a cookie would pass. If the
-  cookie is absent, hold the bump and find out what the new flow expects. Note both requests go through
-  nginx, so rule that out as the source of the 204 before blaming qBittorrent
-
 ## LazyLibrarian
 
 - [ ] Drop `patches/lazylibrarian/lazylibrarian/auth.py` once it is no longer

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -79,24 +79,31 @@ for what was fixed and when.
 
 ## Jellyfin wiring
 
-- [ ] Stop `ensure_jellyfin_connection` failing silently, and work out why it
-  fails for `lidarr`. `scripts/wire-connections.sh:1003` calls it with
-  `|| true`, so a failure leaves the app without the connection while `make wire_connections`
-  still reports success, and the first sign of it is
-  `test_jellyfin_connection_matches_what_the_app_supports[lidarr]` failing later
-  with `supports MediaBrowser=True but wired=False`. Seen on two runs on
-  2026-08-18 (`32176749677` on #72 and `32179005406` on #77), both shortly after
-  the Jellyfin 10.11.10 bump merged unattended in #76 at 19:17Z, and both passed
-  on a retry, so the bump appears to have widened a race rather than broken
-  anything outright. Two things to do, and the first stands on its own: the
-  Prowlarr path in the same file already collects failures in `PROWLARR_FAILED`
-  precisely "so the end of `wire_prowlarr_apps` can report them instead of
-  letting a partial result look identical to a complete one", and the Jellyfin
-  path should do the same rather than swallow. Then find the actual failure,
-  which the reporting will finally make visible. This matters more than a normal
-  flake now that dependency updates merge unattended: an intermittent test means
-  a bot pull request stalls at random and waits for a person, which is the one
-  outcome the automation exists to avoid
+- [ ] Confirm the `ensure_jellyfin_connection` race is actually closed, once
+  `/run-tests` runs against this change. `scripts/wire-connections.sh` used to
+  call it with `|| true`, so a failure left the app without the connection
+  while `make wire_connections` still reported success. That swallow is gone:
+  the same reasoning `PROWLARR_FAILED` already used in this file, "so the end
+  of the run can report them instead of letting a partial result look
+  identical to a complete one", now applies to the Jellyfin path too, via a
+  `JELLYFIN_FAILED` array collected as each arr app's job finishes.
+
+  The actual failure behind
+  `test_jellyfin_connection_matches_what_the_app_supports[lidarr]` (`supports
+  MediaBrowser=True but wired=False`, seen twice on 2026-08-18, runs
+  `32176749677` on #72 and `32179005406` on #77, both shortly after the
+  Jellyfin 10.11.10 bump merged unattended in #76) is right there in both
+  runs' own logs, and it is the same one both times: lidarr gets through its
+  WebUI login and both download clients, then `jellyfin_host_for` logs
+  `WARNING: Jellyfin is running but not reachable from this container` and
+  gives up. That function tried each candidate host once, with a 5 second cap
+  each, unlike almost every other first boot readiness check in this file,
+  which retries for up to 180s. It is now wrapped in this file's own `retry`
+  helper the same way, up to 120s, which should clear the same race the two
+  observed runs hit. Marking this pull request ready and commenting
+  `/run-tests` is deliberately left to a person rather than done here, so the
+  fix has not yet been checked against a real run; watch the next
+  lidarr Jellyfin result to close this out
 
 ## CodeRabbit
 

--- a/scripts/rotate-passwords.sh
+++ b/scripts/rotate-passwords.sh
@@ -931,8 +931,17 @@ PYEOF
   fi
 
   echo "[qBittorrent] Logging in with current password..."
+  # --data-urlencode, not -d: this password is read back from Sonarr's database
+  # and so can be anything a person once typed, where a raw -d body would let
+  # an `&` split it into extra parameters, a `+` arrive as a space, and a
+  # literal `%26` decode to `&`. Any of those sends a password that is not the
+  # stored one, and the login then fails for a reason nothing in the output
+  # would explain. The validation request below is unaffected, since it only
+  # ever sees a generated password from a restricted character set, but this
+  # one reads whatever is already there.
   container_curl qbittorrent -sk -c /tmp/qbt_cookies.txt -o /dev/null \
-    -d "username=qbittorrent&password=${current_password}" \
+    --data-urlencode "username=qbittorrent" \
+    --data-urlencode "password=${current_password}" \
     "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/auth/login"
 
   # Same reasoning as qbittorrent_api_ok below: confirmed live against 5.1.4, a

--- a/scripts/rotate-passwords.sh
+++ b/scripts/rotate-passwords.sh
@@ -931,16 +931,36 @@ PYEOF
   fi
 
   echo "[qBittorrent] Logging in with current password..."
-  container_curl qbittorrent -sk -c /tmp/qbt_cookies.txt \
+  container_curl qbittorrent -sk -c /tmp/qbt_cookies.txt -o /dev/null \
     -d "username=qbittorrent&password=${current_password}" \
-    "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/auth/login" \
-    >/dev/null
+    "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/auth/login"
+
+  # Same reasoning as qbittorrent_api_ok below: confirmed live against 5.1.4, a
+  # refused login still answers 200, so the status says nothing and the cookie
+  # jar is what proves the session is real. Without this the rotation would
+  # carry on and rewrite every consumer's stored credential with a password
+  # qBittorrent never accepted, leaving the whole stack unable to log in. The
+  # jar is the Netscape format, so field 6 is the cookie name and field 7 its
+  # value; the name is SID on 5.1.4 and QBT_SID_<port> on 5.2.2.
+  if ! podman exec qbittorrent \
+    awk '$6 ~ /SID/ && $7 != "" { found = 1 } END { exit !found }' \
+    /tmp/qbt_cookies.txt 2>/dev/null; then
+    podman exec qbittorrent rm -f /tmp/qbt_cookies.txt
+    echo "[qBittorrent] Login with the current password was refused, so no session was established. Aborting rotation." >&2
+    exit 1
+  fi
 
   echo "[qBittorrent] Setting new WebUI password..."
-  container_curl qbittorrent -sk -b /tmp/qbt_cookies.txt \
+  local set_code
+  set_code=$(container_curl qbittorrent -sk -b /tmp/qbt_cookies.txt -o /dev/null \
+    -w '%{http_code}' \
     --data-urlencode "json={\"web_ui_password\":\"${new_password}\"}" \
-    "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/app/setPreferences" \
-    >/dev/null
+    "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/app/setPreferences")
+  if [[ "$set_code" != 2* ]]; then
+    podman exec qbittorrent rm -f /tmp/qbt_cookies.txt
+    echo "[qBittorrent] setPreferences answered HTTP ${set_code}, so the new password was not applied. Aborting rotation." >&2
+    exit 1
+  fi
 
   # The cookie file lives inside the container (curl ran via podman exec),
   # so it must be removed there, not on the host.
@@ -1718,14 +1738,23 @@ nzbhydra_login_ok() {
 }
 
 qbittorrent_api_ok() {
-  local code
-  code=$(container_curl qbittorrent -sk -o /dev/null -w '%{http_code}' \
+  # A successful login answers 200 on qBittorrent 5.1.4 and 204 on 5.2.2
+  # (confirmed directly against standalone containers of both), so the status
+  # check accepts any 2xx rather than the exact code either version happens to
+  # use. The status alone is not enough to call the login good, though:
+  # confirmed live against 5.1.4, a REJECTED login also answers 200, with the
+  # body "Fails." and no cookie, so a status-only check passes a password that
+  # qBittorrent just refused. The session cookie is the part that only a real
+  # login produces, so require it too. Its name is version dependent, a bare
+  # SID on 5.1.4 and a port suffixed QBT_SID_<port> on 5.2.2, hence the
+  # substring match rather than one literal name.
+  local response code
+  response=$(container_curl qbittorrent -sk -o /dev/null -D - -w '\n%{http_code}' \
     "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/auth/login" \
     -d "username=qbittorrent&password=$1")
-  # A successful login answers 200 on qBittorrent 5.1.4 and 204 on 5.2.2
-  # (confirmed directly against standalone containers of both), so this
-  # accepts any 2xx rather than the exact code either version happens to use.
-  [[ "$code" == 2* ]]
+  code="${response##*$'\n'}"
+  [[ "$code" == 2* ]] || return 1
+  grep -qiE '^set-cookie:[[:space:]]*[^=]*SID[^=]*=..*' <<<"$response"
 }
 
 sabnzbd_key_ok() {

--- a/scripts/rotate-passwords.sh
+++ b/scripts/rotate-passwords.sh
@@ -1722,7 +1722,10 @@ qbittorrent_api_ok() {
   code=$(container_curl qbittorrent -sk -o /dev/null -w '%{http_code}' \
     "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/auth/login" \
     -d "username=qbittorrent&password=$1")
-  [[ "$code" == "200" ]]
+  # A successful login answers 200 on qBittorrent 5.1.4 and 204 on 5.2.2
+  # (confirmed directly against standalone containers of both), so this
+  # accepts any 2xx rather than the exact code either version happens to use.
+  [[ "$code" == 2* ]]
 }
 
 sabnzbd_key_ok() {

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -204,7 +204,7 @@ start_job() {
 
 wait_job() {
   local name="$1"
-  wait "${JOB_PID[$name]}" || true
+  wait "${JOB_PID[$name]}"
 }
 
 # ---------------------------------------------------------------------------
@@ -881,6 +881,10 @@ ensure_sabnzbd_client() {
 # alias for the host, which is what works when LAN_IP is still the
 # .env.example placeholder, CI being the case that matters. host.docker
 # .internal covers RUNTIME=docker.
+# Sets JELLYFIN_REACHABLE_HOST as a side effect rather than printing the
+# candidate to stdout, the same reasoning as detect_jellyfin_base_url's own
+# comment: the caller wraps this in retry(), and retry() only checks exit
+# status, not output.
 jellyfin_host_for() {
   local container="$1" candidate
   for candidate in "$LAN_IP" host.containers.internal host.docker.internal; do
@@ -888,12 +892,19 @@ jellyfin_host_for() {
     if container_curl "$container" -s --fail --max-time 5 \
       "http://${candidate}:${JELLYFIN_HTTP_PORT}${JELLYFIN_BASE_URL}/System/Info/Public" \
       >/dev/null 2>&1; then
-      printf '%s' "$candidate"
+      JELLYFIN_REACHABLE_HOST="$candidate"
       return 0
     fi
   done
   return 1
 }
+
+# Names of arr apps whose Jellyfin connection did not succeed this run, so
+# the end of the run can report them instead of letting wire_arr_app's own
+# handling of ensure_jellyfin_connection make a partial result look
+# identical to a complete one, matching PROWLARR_FAILED's own reasoning
+# above.
+JELLYFIN_FAILED=()
 
 # Tells Jellyfin to rescan when an import, upgrade or rename changes the
 # library. Without it Jellyfin only notices on its own scheduled scan, so a
@@ -919,11 +930,24 @@ ensure_jellyfin_connection() {
     return 0
   fi
 
-  local jellyfin_host
-  if ! jellyfin_host=$(jellyfin_host_for "$container"); then
+  # Confirmed live (GitHub Actions runs 32176749677 and 32179005406, both on
+  # 2026-08-18): this is the actual failure behind
+  # test_jellyfin_connection_matches_what_the_app_supports[lidarr], not the
+  # POST below. Both runs logged this exact warning for lidarr and nothing
+  # else unusual before it; Jellyfin's own setup had already produced a real
+  # API key by that point (the check above already passed), so what was not
+  # yet ready was the host path this container reaches Jellyfin through, not
+  # Jellyfin itself. jellyfin_host_for previously tried each candidate host
+  # exactly once with a 5 second cap each, unlike almost every other
+  # first-boot readiness check in this file, which retries for up to 180s.
+  # Wrapping it the same way self-heals the race instead of giving up on the
+  # first attempt.
+  local JELLYFIN_REACHABLE_HOST=""
+  if ! retry 120 "[$app_name]" jellyfin_host_for "$container"; then
     echo "[$app_name] WARNING: Jellyfin is running but not reachable from this container; skipping its connection."
-    return 0
+    return 1
   fi
+  local jellyfin_host="$JELLYFIN_REACHABLE_HOST"
 
   local schema
   schema=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "${base_url}/schema" |
@@ -1000,11 +1024,19 @@ wire_arr_app() {
   ensure_arr_host_prereqs "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key"
   ensure_qbittorrent_client "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key" "$qbit_category"
   ensure_sabnzbd_client "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key" "$sab_category"
-  ensure_jellyfin_connection "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key" || true
+  # Not "|| true": the caller needs to know whether this actually succeeded,
+  # so the dispatch loop below can collect it into JELLYFIN_FAILED instead of
+  # this looking the same as every legitimate skip inside the function itself
+  # (Jellyfin disabled, no API key yet, connection already there, app doesn't
+  # support it), all of which still return 0 on purpose.
+  local jellyfin_status=0
+  ensure_jellyfin_connection "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key" || jellyfin_status=$?
 
   if [[ "$app_name" == "readarr" ]]; then
     ensure_readarr_metadata_source "$container" "$scheme" "$port" "$api_ver" "$key" || true
   fi
+
+  return "$jellyfin_status"
 }
 
 # ---------------------------------------------------------------------------
@@ -1515,10 +1547,27 @@ start_job sonarr wire_arr_app sonarr sonarr http "$SONARR_HTTP_PORT" v3 sonarr t
 start_job whisparr wire_arr_app whisparr whisparr https "$WHISPARR_HTTPS_PORT" v3 whisparr mature
 start_job prowlarr wire_prowlarr_apps
 
-for name in audiobookshelf calibre calibre-web jellyfin \
-  lidarr radarr readarr sonarr whisparr prowlarr; do
-  wait_job "$name"
+for name in audiobookshelf calibre calibre-web jellyfin prowlarr; do
+  wait_job "$name" || true
 done
+
+# Each of these five ran wire_arr_app, which now returns whether its own
+# Jellyfin connection actually succeeded (see ensure_jellyfin_connection and
+# JELLYFIN_FAILED above), so their status is worth keeping instead of
+# discarding like the jobs above.
+for name in lidarr radarr readarr sonarr whisparr; do
+  if ! wait_job "$name"; then
+    JELLYFIN_FAILED+=("$name")
+  fi
+done
+
+if [[ ${#JELLYFIN_FAILED[@]} -gt 0 ]]; then
+  echo "[Jellyfin] WARNING: these apps did NOT get their Jellyfin connection wired:"
+  for failed in "${JELLYFIN_FAILED[@]}"; do
+    echo "[Jellyfin]   - ${failed}"
+  done
+  echo "[Jellyfin] Re-run 'make wire_connections' once Jellyfin and the app are both up."
+fi
 
 # Sequential, not part of the parallel batch above: this stops/starts the
 # mylar container, which would otherwise race with wire_prowlarr_apps'

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -231,7 +231,19 @@ wait_job() {
 # JELLYFIN_DETECTED_BASE_URL as a side effect since retry() only checks
 # exit status, not output.
 detect_jellyfin_base_url() {
-  local host_url="http://127.0.0.1:${JELLYFIN_HTTP_PORT}"
+  # 8096 rather than JELLYFIN_HTTP_PORT, deliberately. This curl runs inside
+  # the jellyfin container, and docker-compose-media-library.yml publishes the
+  # service as `${JELLYFIN_HTTP_PORT}:8096`, so that variable is the HOST side
+  # of the mapping while the server itself always listens on 8096. The two
+  # coincide with .env.example's default and the bug stays invisible; change
+  # the published port, which .env exists to allow, and this dialled a port
+  # nothing listens on. Confirmed live with JELLYFIN_HTTP_PORT=18096: inside
+  # the container 18096 is refused and 8096 answers 200, so first-run setup
+  # burned the full 180s retry and was skipped on every single start.
+  # jellyfin_host_for is the opposite case and correctly keeps the variable:
+  # it runs inside an arr container, reaching Jellyfin across the host, where
+  # the published port is exactly what it must use.
+  local host_url="http://127.0.0.1:8096"
   local info
   # `jq -e '.StartupWizardCompleted'` looked right but isn't: jq -e's exit
   # status reflects the truthiness of the printed value, not whether the key
@@ -935,11 +947,44 @@ ensure_jellyfin_connection() {
     return 0
   fi
 
+  # Both API reads below are checked rather than left bare. This function is
+  # called in an `||` list, which suspends `set -e` for everything inside it,
+  # so an unguarded `existing=$(...)` that failed would carry on with an empty
+  # value and return a confident looking skip. That is the very silent success
+  # this change exists to remove, so a read that fails is reported as a
+  # failure. `set -o pipefail` at the top of this file is what makes the
+  # curl half of each pipeline count, not just jq's status.
   local existing
-  existing=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "$base_url" |
-    jq 'map(select(.implementation == "MediaBrowser")) | first')
+  if ! existing=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "$base_url" |
+    jq 'map(select(.implementation == "MediaBrowser")) | first'); then
+    echo "[$app_name] WARNING: could not read its notification list; skipping its Jellyfin connection."
+    return 1
+  fi
   if [[ -n "$existing" && "$existing" != "null" ]]; then
     echo "[$app_name] Jellyfin connection already exists, skipping."
+    return 0
+  fi
+
+  local schema
+  if ! schema=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "${base_url}/schema" |
+    jq 'map(select(.implementation == "MediaBrowser")) | first'); then
+    echo "[$app_name] WARNING: could not read its notification schema; skipping its Jellyfin connection."
+    return 1
+  fi
+
+  # Not every app offers this. Readarr has no MediaBrowser implementation at
+  # all, since Jellyfin does not take a book library from it; its equivalents
+  # are Kavita and Subsonic. Asking rather than assuming keeps the list of
+  # apps here honest as upstream changes.
+  #
+  # Deliberately answered before the reachability retry below, not after. An
+  # app that cannot use a Jellyfin connection at all must not sit through a
+  # 120s wait for Jellyfin, and must never be reported as having missed a
+  # connection it was never going to make: reachability failing returns
+  # non-zero, so with the order reversed an unreachable Jellyfin would file
+  # Readarr under JELLYFIN_FAILED.
+  if [[ -z "$schema" || "$schema" == "null" ]]; then
+    echo "[$app_name] Does not support Jellyfin connections, skipping."
     return 0
   fi
 
@@ -961,19 +1006,6 @@ ensure_jellyfin_connection() {
     return 1
   fi
   local jellyfin_host="$JELLYFIN_REACHABLE_HOST"
-
-  local schema
-  schema=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "${base_url}/schema" |
-    jq 'map(select(.implementation == "MediaBrowser")) | first')
-
-  # Not every app offers this. Readarr has no MediaBrowser implementation at
-  # all, since Jellyfin does not take a book library from it; its equivalents
-  # are Kavita and Subsonic. Asking rather than assuming keeps the list of
-  # apps here honest as upstream changes.
-  if [[ -z "$schema" || "$schema" == "null" ]]; then
-    echo "[$app_name] Does not support Jellyfin connections, skipping."
-    return 0
-  fi
 
   echo "[$app_name] Creating Jellyfin connection..."
 

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -906,6 +906,19 @@ jellyfin_host_for() {
 # above.
 JELLYFIN_FAILED=()
 
+# Names of arr apps whose job failed somewhere other than the Jellyfin
+# connection, kept apart from JELLYFIN_FAILED so neither summary claims a
+# cause that is not its own. See wire_arr_app for why the two are
+# distinguishable at all.
+ARR_JOB_FAILED=()
+
+# Exit status wire_arr_app uses for "everything else worked, the Jellyfin
+# connection did not". Any other non-zero status from that job means it died
+# earlier, under `set -e`, before the Jellyfin call was reached. 90 is chosen
+# to sit clear of both the shell's own 1 and 2 and the 126 to 165 range it
+# reserves for "cannot execute", "not found" and fatal signals.
+readonly JELLYFIN_WIRING_FAILED=90
+
 # Tells Jellyfin to rescan when an import, upgrade or rename changes the
 # library. Without it Jellyfin only notices on its own scheduled scan, so a
 # finished download can sit there invisible for hours.
@@ -1029,6 +1042,13 @@ wire_arr_app() {
   # this looking the same as every legitimate skip inside the function itself
   # (Jellyfin disabled, no API key yet, connection already there, app doesn't
   # support it), all of which still return 0 on purpose.
+  #
+  # Reported as JELLYFIN_WIRING_FAILED rather than a plain non-zero status
+  # because the three calls above are not guarded, so under `set -e` any one
+  # of them failing kills this job before the Jellyfin call is ever reached.
+  # A bare "did this job fail" test cannot tell those apart, and would file a
+  # failed qBittorrent client under Jellyfin and tell the reader to re-run
+  # once Jellyfin is up, which would not fix it.
   local jellyfin_status=0
   ensure_jellyfin_connection "$app_name" "$container" "$scheme" "$port" "$api_ver" "$key" || jellyfin_status=$?
 
@@ -1036,7 +1056,10 @@ wire_arr_app() {
     ensure_readarr_metadata_source "$container" "$scheme" "$port" "$api_ver" "$key" || true
   fi
 
-  return "$jellyfin_status"
+  if [[ "$jellyfin_status" -ne 0 ]]; then
+    return "$JELLYFIN_WIRING_FAILED"
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -1551,13 +1574,20 @@ for name in audiobookshelf calibre calibre-web jellyfin prowlarr; do
   wait_job "$name" || true
 done
 
-# Each of these five ran wire_arr_app, which now returns whether its own
-# Jellyfin connection actually succeeded (see ensure_jellyfin_connection and
+# Each of these five ran wire_arr_app, which now reports whether its own
+# Jellyfin connection succeeded (see ensure_jellyfin_connection and
 # JELLYFIN_FAILED above), so their status is worth keeping instead of
-# discarding like the jobs above.
+# discarding like the jobs above. JELLYFIN_WIRING_FAILED is the only status
+# that means the Jellyfin connection specifically; anything else non-zero is
+# a job that died earlier and is recorded separately rather than blamed on
+# Jellyfin.
 for name in lidarr radarr readarr sonarr whisparr; do
-  if ! wait_job "$name"; then
+  arr_status=0
+  wait_job "$name" || arr_status=$?
+  if [[ "$arr_status" -eq "$JELLYFIN_WIRING_FAILED" ]]; then
     JELLYFIN_FAILED+=("$name")
+  elif [[ "$arr_status" -ne 0 ]]; then
+    ARR_JOB_FAILED+=("$name (exit ${arr_status})")
   fi
 done
 
@@ -1567,6 +1597,15 @@ if [[ ${#JELLYFIN_FAILED[@]} -gt 0 ]]; then
     echo "[Jellyfin]   - ${failed}"
   done
   echo "[Jellyfin] Re-run 'make wire_connections' once Jellyfin and the app are both up."
+fi
+
+if [[ ${#ARR_JOB_FAILED[@]} -gt 0 ]]; then
+  echo "[arr] WARNING: these apps did not finish wiring, and stopped before"
+  echo "[arr] their Jellyfin connection was even attempted:"
+  for failed in "${ARR_JOB_FAILED[@]}"; do
+    echo "[arr]   - ${failed}"
+  done
+  echo "[arr] Check the output above for the first error each one printed."
 fi
 
 # Sequential, not part of the parallel batch above: this stops/starts the

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -31,6 +31,29 @@ def _qbittorrent_password():
     )
 
 
+def _assert_qbittorrent_login_succeeded(resp):
+    """A successful login only ever means a successful status plus a real
+    session cookie; the exact status and body are not something upstream
+    promised to keep. Confirmed directly against standalone containers of
+    both versions, bypassing nginx entirely: qBittorrent 5.1.4 answers a
+    successful login with 200 and the body 'Ok.', while 5.2.2 answers with
+    204 and an empty body instead, yet both set a working session cookie and
+    both let that cookie through to a later authenticated call. The cookie's
+    own name changed too, from a bare 'SID' on 5.1.4 to a port suffixed
+    'QBT_SID_<port>' on 5.2.2, so this checks for any cookie whose name
+    contains 'SID' rather than one literal name. Only the status and body
+    are dropped here; a cookie check alone would let an error response that
+    happened to set a cookie pass, so the status is still required too.
+    """
+    assert 200 <= resp.status_code < 300, (
+        f"qBittorrent login failed: {resp.status_code} {resp.text!r}"
+    )
+    sid_cookies = [value for name, value in resp.cookies.items() if "SID" in name]
+    assert any(sid_cookies), (
+        f"qBittorrent login set no session cookie: {dict(resp.cookies)!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # qBittorrent
 # ---------------------------------------------------------------------------
@@ -52,8 +75,7 @@ def test_qbittorrent_api_login(running_containers):
         verify=False,
         timeout=TIMEOUT,
     )
-    assert resp.status_code == 200
-    assert resp.text.strip() == "Ok.", f"qBittorrent login failed: {resp.text!r}"
+    _assert_qbittorrent_login_succeeded(resp)
 
 
 def test_qbittorrent_web_session_login(running_containers):
@@ -72,7 +94,7 @@ def test_qbittorrent_web_session_login(running_containers):
     resp = session.post(
         login_url, data={"username": username, "password": password}, timeout=TIMEOUT
     )
-    assert resp.status_code == 200 and resp.text.strip() == "Ok."
+    _assert_qbittorrent_login_succeeded(resp)
 
     # Verify the session cookie grants access to a protected endpoint
     version_resp = session.get(


### PR DESCRIPTION
Three unrelated things landed on this branch together: two red suite
findings that needed fixing, and the operational finding this PR started
with, which stands on its own and is unchanged below.

## Jellyfin wiring: a swallowed failure, and its actual cause

`scripts/wire-connections.sh` called `ensure_jellyfin_connection` with
`|| true`, so a failed Jellyfin connection left an arr app unwired while
`make wire_connections` still reported success. The Prowlarr path in the
same file already collects failures into `PROWLARR_FAILED` for exactly this
reason; the Jellyfin path now does the same into a `JELLYFIN_FAILED` array,
reported once every job finishes, with the legitimate skips (Jellyfin
disabled, no API key yet, connection already there, app doesn't support it)
still not counted as failures.

Pulling the actual logs from the two runs that hit
`test_jellyfin_connection_matches_what_the_app_supports[lidarr]` (GitHub
Actions runs `32176749677` on #72 and `32179005406` on #77, both shortly
after the Jellyfin 10.11.10 bump merged unattended in #76) shows the same
failure both times: lidarr gets through its WebUI login and both download
clients, then `jellyfin_host_for` logs "Jellyfin is running but not
reachable from this container" and gives up. That function tried each
candidate host once, with a 5 second cap each, unlike almost every other
first boot readiness check in this file, which retries for up to 180s. It
is now wrapped in this file's own `retry` helper the same way, up to 120s.

Not yet confirmed against a real run: marking this pull request ready and
commenting `/run-tests` is left to a person, so docs/TODO.md keeps an item
open to watch the next lidarr Jellyfin result rather than closing it here.

## qBittorrent 5.2.2: still authenticates, just answers differently

`tests/test_auth.py` asserted `status_code == 200` and a body of `Ok.` on
`/api/v2/auth/login`, which is what qBittorrent 5.1.4 answers. Renovate's
PR #83 bumps to 5.2.2, which answers a successful login with `204` and an
empty body, so both assertions failed and #83 was correctly red, but that
left open whether authentication still worked at all.

Checked directly rather than guessing: ran standalone qBittorrent
containers of both versions with podman (the same image reference #83
proposes for 5.2.2), and posted to `/api/v2/auth/login` from inside each
container's own network namespace, bypassing nginx entirely.

| | 5.1.4 | 5.2.2 |
| --- | --- | --- |
| Status | 200 | 204 |
| Body | `Ok.` | empty |
| Cookie | `SID=<value>` | `QBT_SID_<port>=<value>` |
| Follow up `GET /api/v2/app/version` with that cookie | 200, `v5.1.4` | 200, `v5.2.2` |

Both versions set a real session cookie and both let it through to an
authenticated call afterward, so login still works under 5.2.2. The cookie
name itself changed too, from a bare `SID` to a port suffixed
`QBT_SID_<port>`, confirmed by running the WebUI on a non-default port and
watching the cookie name track it.

`test_qbittorrent_api_login` and `test_qbittorrent_web_session_login` now
accept any 2xx status and require a cookie whose name contains `SID` with a
real value, dropping only the exact `200` and the `Ok.` body that upstream
is free to change. The status check stays: a cookie check alone would let
an error response that happened to set a cookie pass. This passes against
both versions, confirmed with the same two probe containers. Our own suite
still runs 5.1.4, so this needed to keep working there too, not only under
the version #83 proposes.

`scripts/rotate-passwords.sh`'s `qbittorrent_api_ok` had the same literal
`200` check, used to confirm a rotated password logs in; it now accepts any
2xx for the same reason. Grepped the rest of `tests/` and `scripts/` for
other places asserting on the qBittorrent login status or its body; nothing
else does.

`QBITTORRENT_VERSION` itself is untouched here; bumping it is #83's job.

## CodeRabbit: a rate limited review reports green

Records a problem found while checking whether a green `CodeRabbit` check
can be trusted as a merge gate. It cannot, and three pull requests merged
with no review because of it.

CodeRabbit reports through the **legacy commit status API**, not check
runs. That API offers only `error`, `failure`, `pending` and `success`,
with no `neutral`. When the included-review quota is exhausted, the status
resolves to `success` with the description `Review rate limited`, which
nothing reading the status can tell apart from `success` with `Review
completed`.

| PR | Final CodeRabbit status | Merged |
| --- | --- | --- |
| #86 | `success` / Review rate limited | 2026-08-19 13:26Z |
| #88 | `success` / Review rate limited | 2026-08-19 18:27Z |
| #87 | `success` / Review rate limited | 2026-08-19 18:47Z |
| #82, #85, #90 | `success` / Review completed | reviewed |

None of #86, #87 or #88 has a `Review completed` entry anywhere in its
status history. #87 is titled "Stagger dependency updates, and stop losing
CodeRabbit reviews" and was itself never read.

Also drops the `(3/hour)` quota figure from the bullet above the new item.
The review on #90 reported "up to 10 included reviews per hour; 5 remain",
so the recorded number was wrong and the correct one is not established.
That bullet now points at the new item rather than restating the same
observation twice.

`reviews.fail_commit_status` is the only related setting in
`schema.v2.json` and does not cover this: it acts on review errors, not on
declines. `required_conversation_resolution` is already enabled on `main`,
so the "every thread addressed" half is enforced today; only "a review
happened" is missing. The new item warns against the tempting wrong fix,
marking the `CodeRabbit` context required: bot pull requests get no status
at all, and a required context that is absent blocks a merge indefinitely,
so that would freeze every Renovate pull request while still passing every
rate limited human one.

## Notes

This PR carries real code now, unlike its earlier prose only state, so
`Detect Changed Paths` should report `code=true` and the normal
`Integration Tests` gate applies once it is marked ready rather than the
`Docs Only Waiver` path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - qBittorrent authentication now supports special characters in passwords, validates successful responses, and confirms a session before password changes.
  - Setup connections retry Jellyfin availability for up to two minutes before reporting failure.
  - Background setup errors are no longer silently hidden; Jellyfin and Arr failures now include clearer status details.
  - Improved compatibility with qBittorrent responses using HTTP 200 or 204.

- **Documentation**
  - Updated setup guidance and review notes, including Jellyfin retry behavior and rate-limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->