### PR TITLE
Scope container names so a second checkout can run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -302,6 +302,28 @@ SABNZBD_EXPORTER_PROFILE=disabled
 JACKETT_PROFILE=disabled
 NZBGET_PROFILE=disabled
 
+### CONTAINER NAMES
+# Prefix prepended to every container_name, and to the container reference in
+# the download clients' network_mode. Empty by default, so a deployment's
+# containers are named exactly as they always have been and nothing that talks
+# to them by name has to change.
+#
+# It exists so a second checkout can run beside a deployment. Podman container
+# names are global while pods and networks are per project, so two checkouts
+# with the same names collide on the names alone: whichever one owns them holds
+# them, and the other's `make start` fails to create a single container while
+# still exiting zero. Confirmed by running both at once, where the second
+# checkout produced 33 "the container name is already in use" errors and ended
+# with an empty pod.
+#
+# Set this in the second checkout's own .env, not here, and give it a trailing
+# separator: CONTAINER_PREFIX=dev- yields dev-gluetun, dev-sonarr and so on.
+# Service names are untouched, which is what keeps this cheap: podman-compose
+# takes each container's network alias from the service name, so inter-container
+# DNS, nginx's upstreams, Prometheus's scrape targets and Homepage's widget URLs
+# all keep resolving whatever this is set to.
+CONTAINER_PREFIX=
+
 ### VERSIONS
 # Lines without a # renovate: annotation use floating/channel tags managed manually.
 # tests/test_renovate_pins.py enforces that: a pin added here with no annotation

--- a/Makefile
+++ b/Makefile
@@ -732,7 +732,7 @@ define wait_for_gluetun
 			--format 'status={{.State.Status}} health={{.State.Health.Status}} exitcode={{.State.ExitCode}}' \
 			2>/dev/null || echo "(gluetun could not be inspected; it may never have been created)"; \
 		echo "--- gluetun log, last 40 lines ---"; \
-		$(RUNTIME) logs --tail 40 gluetun 2>&1 || echo "(no logs available)"; \
+		$(RUNTIME) logs --tail 40 $(CONTAINER_PREFIX)gluetun 2>&1 || echo "(no logs available)"; \
 		exit 1; \
 	}
 endef
@@ -762,11 +762,11 @@ restart:
 VPN_DEPENDENT_CONTAINERS := qbittorrent jdownloader2 sabnzbd
 
 heal_vpn_dependents:
-	@if [ "$$($(RUNTIME) inspect gluetun --format '{{.State.Running}}' 2>/dev/null)" != "true" ]; then \
+	@if [ "$$($(RUNTIME) inspect $(CONTAINER_PREFIX)gluetun --format '{{.State.Running}}' 2>/dev/null)" != "true" ]; then \
 		echo "gluetun is not running, nothing to heal."; \
 		exit 0; \
 	fi; \
-	gluetun_started=$$($(RUNTIME) inspect gluetun --format '{{json .State.StartedAt}}' | tr -d '"'); \
+	gluetun_started=$$($(RUNTIME) inspect $(CONTAINER_PREFIX)gluetun --format '{{json .State.StartedAt}}' | tr -d '"'); \
 	gluetun_epoch=$$(date -d "$$gluetun_started" +%s); \
 	stale=""; \
 	for c in $(VPN_DEPENDENT_CONTAINERS); do \

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ bootstrap: configs/flaresolverr/config/chromedriver
 		echo "ERROR: Gluetun did not report a running VPN connection after 90s."; \
 		echo "This usually means the WireGuard key in configs/gluetun/.secret is wrong,"; \
 		echo "or the provider/server settings in configs/gluetun/.env don't match your"; \
-		echo "account. Check 'podman logs gluetun' for the exact reason, fix"; \
+		echo "account. Check 'podman logs $(CONTAINER_PREFIX)gluetun' for the exact reason, fix"; \
 		echo "configs/gluetun/.env or .secret, then re-run 'make bootstrap'."; \
 		exit 1; \
 	fi
@@ -474,8 +474,8 @@ down:
 					echo "$$remaining" | xargs -r podman kill >/dev/null || true; \
 				fi; \
 			fi; \
-			echo "$$project_containers" | grep -vx gluetun | xargs -r podman rm --force --time 0 >/dev/null || true; \
-			echo "$$project_containers" | grep -x gluetun | xargs -r podman rm --force --time 0 >/dev/null || true; \
+			echo "$$project_containers" | grep -vx $(CONTAINER_PREFIX)gluetun | xargs -r podman rm --force --time 0 >/dev/null || true; \
+			echo "$$project_containers" | grep -x $(CONTAINER_PREFIX)gluetun | xargs -r podman rm --force --time 0 >/dev/null || true; \
 			for network in edge wan apps services media observability; do \
 				podman network rm "$(COMPOSE_PROJECT_NAME)_$$network" >/dev/null 2>&1 || true; \
 			done; \
@@ -723,12 +723,12 @@ pull_docker_images:
 # scheduled it.
 define wait_for_gluetun
 	@echo "Waiting for VPN gateway to be healthy (up to 180s)..."
-	@timeout 180 sh -c 'until $(RUNTIME) inspect gluetun --format "{{.State.Running}} {{.State.Health.Status}}" 2>/dev/null | grep -qx "true healthy" \
-		|| { $(RUNTIME) inspect gluetun --format "{{.State.Running}}" 2>/dev/null | grep -qx true \
-			&& $(RUNTIME) exec gluetun wget -q -O /dev/null http://127.0.0.1:9999/ 2>/dev/null; }; do sleep 5; done' || { \
+	@timeout 180 sh -c 'until $(RUNTIME) inspect $(CONTAINER_PREFIX)gluetun --format "{{.State.Running}} {{.State.Health.Status}}" 2>/dev/null | grep -qx "true healthy" \
+		|| { $(RUNTIME) inspect $(CONTAINER_PREFIX)gluetun --format "{{.State.Running}}" 2>/dev/null | grep -qx true \
+			&& $(RUNTIME) exec $(CONTAINER_PREFIX)gluetun wget -q -O /dev/null http://127.0.0.1:9999/ 2>/dev/null; }; do sleep 5; done' || { \
 		echo "ERROR: gluetun did not become healthy in time"; \
 		echo "--- gluetun state ---"; \
-		$(RUNTIME) inspect gluetun \
+		$(RUNTIME) inspect $(CONTAINER_PREFIX)gluetun \
 			--format 'status={{.State.Status}} health={{.State.Health.Status}} exitcode={{.State.ExitCode}}' \
 			2>/dev/null || echo "(gluetun could not be inspected; it may never have been created)"; \
 		echo "--- gluetun log, last 40 lines ---"; \

--- a/Makefile
+++ b/Makefile
@@ -759,6 +759,9 @@ restart:
 # happens. Detect and fix it after the fact: any container sharing gluetun's
 # network namespace whose StartedAt predates gluetun's current StartedAt has
 # a stale namespace and gets restarted.
+# Service names, not container names: heal_vpn_dependents prefixes each one
+# with CONTAINER_PREFIX itself, so this list stays readable and stays valid
+# whatever a checkout sets.
 VPN_DEPENDENT_CONTAINERS := qbittorrent jdownloader2 sabnzbd
 
 heal_vpn_dependents:
@@ -770,13 +773,14 @@ heal_vpn_dependents:
 	gluetun_epoch=$$(date -d "$$gluetun_started" +%s); \
 	stale=""; \
 	for c in $(VPN_DEPENDENT_CONTAINERS); do \
-		if [ "$$($(RUNTIME) inspect $$c --format '{{.State.Running}}' 2>/dev/null)" != "true" ]; then \
+		container="$(CONTAINER_PREFIX)$$c"; \
+		if [ "$$($(RUNTIME) inspect $$container --format '{{.State.Running}}' 2>/dev/null)" != "true" ]; then \
 			continue; \
 		fi; \
-		c_started=$$($(RUNTIME) inspect $$c --format '{{json .State.StartedAt}}' | tr -d '"'); \
+		c_started=$$($(RUNTIME) inspect $$container --format '{{json .State.StartedAt}}' | tr -d '"'); \
 		c_epoch=$$(date -d "$$c_started" +%s); \
 		if [ "$$c_epoch" -lt "$$gluetun_epoch" ]; then \
-			stale="$$stale $$c"; \
+			stale="$$stale $$container"; \
 		fi; \
 	done; \
 	if [ -n "$$stale" ]; then \

--- a/docker-compose-media-library.yml
+++ b/docker-compose-media-library.yml
@@ -73,7 +73,7 @@ services:
   jellyfin:
     <<: *limit-jellyfin
     image: docker.io/linuxserver/jellyfin:${JELLYFIN_VERSION}
-    container_name: jellyfin
+    container_name: ${CONTAINER_PREFIX}jellyfin
     profiles: ["${JELLYFIN_PROFILE}"]
     networks:
       - media
@@ -120,7 +120,7 @@ services:
   audiobookshelf:
     <<: *limit-audiobookshelf
     image: ghcr.io/advplyr/audiobookshelf:${AUDIOBOOKSHELF_VERSION}
-    container_name: audiobookshelf
+    container_name: ${CONTAINER_PREFIX}audiobookshelf
     profiles: ["${AUDIOBOOKSHELF_PROFILE}"]
     networks:
       media:
@@ -153,7 +153,7 @@ services:
   calibre:
     <<: *limit-calibre
     image: docker.io/linuxserver/calibre:${CALIBRE_VERSION}
-    container_name: calibre
+    container_name: ${CONTAINER_PREFIX}calibre
     profiles: ["${CALIBRE_PROFILE}"]
     networks:
       media:
@@ -202,7 +202,7 @@ services:
   calibre-web:
     <<: *limit-calibreweb
     image: docker.io/linuxserver/calibre-web:${CALIBREWEB_VERSION}
-    container_name: calibre-web
+    container_name: ${CONTAINER_PREFIX}calibre-web
     profiles: ["${CALIBREWEB_PROFILE}"]
     networks:
       media:
@@ -242,7 +242,7 @@ services:
   korsync:
     <<: *limit-korsync
     image: ghcr.io/nperez0111/koreader-sync:${KORSYNC_VERSION}
-    container_name: korsync
+    container_name: ${CONTAINER_PREFIX}korsync
     profiles: ["${KORSYNC_PROFILE}"]
     networks:
       media:

--- a/docker-compose-nzb.yml
+++ b/docker-compose-nzb.yml
@@ -43,13 +43,13 @@ services:
   sabnzbd:
     <<: *limit-downloaders
     image: docker.io/linuxserver/sabnzbd:${SABNZBD_VERSION}
-    container_name: sabnzbd
+    container_name: ${CONTAINER_PREFIX}sabnzbd
     depends_on:
       ${VPN_PROVIDER}:
         condition: service_healthy
         restart: true
     profiles: ["${SABNZBD_PROFILE}"]
-    network_mode: container:${VPN_PROVIDER}
+    network_mode: container:${CONTAINER_PREFIX}${VPN_PROVIDER}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -93,10 +93,10 @@ services:
   nzbget:
     <<: *limit-downloaders
     image: docker.io/linuxserver/nzbget:${NZBGET_VERSION}
-    container_name: nzbget
+    container_name: ${CONTAINER_PREFIX}nzbget
     depends_on: ["${VPN_PROVIDER}"]
     profiles: ["${NZBGET_PROFILE}"]
-    network_mode: container:${VPN_PROVIDER}
+    network_mode: container:${CONTAINER_PREFIX}${VPN_PROVIDER}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -123,7 +123,7 @@ services:
   nzbhydra2:
     <<: *limit-nzbhydra2
     image: docker.io/linuxserver/nzbhydra2:${NZBHYDRA2_VERSION}
-    container_name: nzbhydra2
+    container_name: ${CONTAINER_PREFIX}nzbhydra2
     profiles: ["${NZBHYDRA2_PROFILE}"]
     networks:
       apps:

--- a/docker-compose-observability.yml
+++ b/docker-compose-observability.yml
@@ -60,7 +60,7 @@ services:
   cadvisor:
     <<: *limit-telemetry
     image: gcr.io/cadvisor/cadvisor:${CADVISOR_VERSION}
-    container_name: cadvisor
+    container_name: ${CONTAINER_PREFIX}cadvisor
     profiles: ["${CADVISOR_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -88,7 +88,7 @@ services:
   podman_exporter:
     <<: *limit-telemetry
     image: quay.io/navidys/prometheus-podman-exporter:${PODMAN_EXPORTER_VERSION}
-    container_name: podman_exporter
+    container_name: ${CONTAINER_PREFIX}podman_exporter
     profiles: ["${PODMAN_EXPORTER_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -108,7 +108,7 @@ services:
   podman_limits_exporter:
     <<: *limit-telemetry
     image: docker.io/library/python:${PODMAN_LIMITS_EXPORTER_VERSION}
-    container_name: podman_limits_exporter
+    container_name: ${CONTAINER_PREFIX}podman_limits_exporter
     profiles: ["${PODMAN_LIMITS_EXPORTER_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -127,7 +127,7 @@ services:
   node_exporter:
     <<: *limit-telemetry
     image: docker.io/prom/node-exporter:${NODE_EXPORTER_VERSION}
-    container_name: node_exporter
+    container_name: ${CONTAINER_PREFIX}node_exporter
     profiles: ["${NODE_EXPORTER_PROFILE}"]
     networks: ["observability"]
     # ports:
@@ -158,7 +158,7 @@ services:
           memory: ${ALLOY_MEMORY}
           cpus: "${TELEMETRY_CPUS}"
     image: docker.io/grafana/alloy:${ALLOY_VERSION}
-    container_name: alloy
+    container_name: ${CONTAINER_PREFIX}alloy
     profiles: ["${ALLOY_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -184,7 +184,7 @@ services:
   log_rotator:
     <<: *limit-log-rotator
     image: docker.io/alpine:${LOG_ROTATOR_VERSION}
-    container_name: log_rotator
+    container_name: ${CONTAINER_PREFIX}log_rotator
     profiles: ["${LOG_ROTATOR_PROFILE}"]
     restart: unless-stopped
     user: "${LOG_ROTATOR_UID}:${LOG_ROTATOR_GID}"
@@ -211,7 +211,7 @@ services:
   prometheus:
     <<: *limit-telemetry
     image: docker.io/prom/prometheus:${PROMETHEUS_VERSION}
-    container_name: prometheus
+    container_name: ${CONTAINER_PREFIX}prometheus
     profiles: ["${PROMETHEUS_PROFILE}"]
     networks: ["observability"]
     # ports:
@@ -243,7 +243,7 @@ services:
   loki:
     <<: *limit-telemetry
     image: docker.io/grafana/loki:${LOKI_VERSION}
-    container_name: loki
+    container_name: ${CONTAINER_PREFIX}loki
     profiles: ["${LOKI_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -264,7 +264,7 @@ services:
   grafana:
     <<: *limit-grafana
     image: docker.io/grafana/grafana-oss:${GRAFANA_VERSION}
-    container_name: grafana
+    container_name: ${CONTAINER_PREFIX}grafana
     profiles: ["${GRAFANA_PROFILE}"]
     networks: ["observability", "apps"]
     # ports:
@@ -296,7 +296,7 @@ services:
   nginx_exporter:
     <<: *limit-telemetry
     image: docker.io/nginx/nginx-prometheus-exporter:${NGINX_EXPORTER_VERSION}
-    container_name: nginx_exporter
+    container_name: ${CONTAINER_PREFIX}nginx_exporter
     profiles: ["${NGINX_EXPORTER_PROFILE}"]
     networks: ["observability"]
     sysctls: ["net.ipv6.conf.all.disable_ipv6=1", net.ipv6.conf.default.disable_ipv6=1, net.ipv6.conf.lo.disable_ipv6=1]
@@ -312,7 +312,7 @@ services:
   qbittorrent_exporter:
     <<: *limit-telemetry
     image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:${QBITTORRENT_EXPORTER_VERSION}
-    container_name: qbittorrent_exporter
+    container_name: ${CONTAINER_PREFIX}qbittorrent_exporter
     profiles: ["${QBITTORRENT_EXPORTER_PROFILE}"]
     networks: ["observability", "services"]
     restart: unless-stopped
@@ -340,7 +340,7 @@ services:
   sabnzbd_exporter:
     <<: *limit-telemetry
     image: docker.io/msroest/sabnzbd_exporter:${SABNZBD_EXPORTER_VERSION}
-    container_name: sabnzbd_exporter
+    container_name: ${CONTAINER_PREFIX}sabnzbd_exporter
     profiles: ["${SABNZBD_EXPORTER_PROFILE}"]
     networks: ["observability", "services"]
     sysctls:

--- a/docker-compose-proxy.yml
+++ b/docker-compose-proxy.yml
@@ -81,7 +81,7 @@ services:
   nginx:
     <<: *limit-nginx
     image: docker.io/nginx:${NGINX_VERSION}
-    container_name: nginx
+    container_name: ${CONTAINER_PREFIX}nginx
     profiles: ["${NGINX_PROFILE}"]
     networks:
       edge: {}
@@ -182,7 +182,7 @@ services:
   homepage:
     <<: *limit-homepage
     image: ghcr.io/gethomepage/homepage:${HOMEPAGE_VERSION}
-    container_name: homepage
+    container_name: ${CONTAINER_PREFIX}homepage
     profiles: ["${HOMEPAGE_PROFILE}"]
     networks:
       apps:

--- a/docker-compose-servarr.yml
+++ b/docker-compose-servarr.yml
@@ -74,7 +74,7 @@ services:
   bazarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/bazarr:${BAZARR_VERSION}
-    container_name: bazarr
+    container_name: ${CONTAINER_PREFIX}bazarr
     profiles: ["${BAZARR_PROFILE}"]
     networks:
       apps:
@@ -97,7 +97,7 @@ services:
   lidarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/lidarr:${LIDARR_VERSION}
-    container_name: lidarr
+    container_name: ${CONTAINER_PREFIX}lidarr
     profiles: ["${LIDARR_PROFILE}"]
     networks:
       apps:
@@ -127,7 +127,7 @@ services:
   prowlarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/prowlarr:${PROWLARR_VERSION}
-    container_name: prowlarr
+    container_name: ${CONTAINER_PREFIX}prowlarr
     profiles: ["${PROWLARR_PROFILE}"]
     networks:
       apps:
@@ -153,7 +153,7 @@ services:
   radarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/radarr:${RADARR_VERSION}
-    container_name: radarr
+    container_name: ${CONTAINER_PREFIX}radarr
     profiles: ["${RADARR_PROFILE}"]
     networks:
       apps:
@@ -181,7 +181,7 @@ services:
   readarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/readarr:${READARR_VERSION}
-    container_name: readarr
+    container_name: ${CONTAINER_PREFIX}readarr
     profiles: ["${READARR_PROFILE}"]
     networks:
       apps:
@@ -209,7 +209,7 @@ services:
   recyclarr:
     <<: *limit-servarr
     image: ghcr.io/recyclarr/recyclarr:${RECYCLARR_VERSION}
-    container_name: recyclarr
+    container_name: ${CONTAINER_PREFIX}recyclarr
     profiles: ["${RECYCLARR_PROFILE}"]
     networks: [apps, services]
     sysctls:
@@ -232,7 +232,7 @@ services:
   sonarr:
     <<: [*servarr-common, *limit-servarr]
     image: docker.io/linuxserver/sonarr:${SONARR_VERSION}
-    container_name: sonarr
+    container_name: ${CONTAINER_PREFIX}sonarr
     profiles: ["${SONARR_PROFILE}"]
     networks:
       apps:
@@ -260,7 +260,7 @@ services:
   flaresolverr:
     <<: *limit-flaresolverr
     image: docker.io/flaresolverr/flaresolverr:${FLARESOLVERR_VERSION}
-    container_name: flaresolverr
+    container_name: ${CONTAINER_PREFIX}flaresolverr
     profiles: ["${FLARESOLVERR_PROFILE}"]
     networks:
       apps:
@@ -292,7 +292,7 @@ services:
   whisparr:
     <<: [*servarr-common, *limit-servarr]
     image: ghcr.io/hotio/whisparr:${WHISPARR_VERSION}
-    container_name: whisparr
+    container_name: ${CONTAINER_PREFIX}whisparr
     profiles: ["${WHISPARR_PROFILE}"]
     networks:
       apps:
@@ -327,7 +327,7 @@ services:
       context: ./build/lazylibrarian
       args:
         BASE_VERSION: ${LAZYLIBRARIAN_VERSION}
-    container_name: lazylibrarian
+    container_name: ${CONTAINER_PREFIX}lazylibrarian
     profiles: ["${LAZYLIBRARIAN_PROFILE}"]
     networks:
       apps:
@@ -359,7 +359,7 @@ services:
       context: ./build/mylar
       args:
         BASE_VERSION: ${MYLAR_VERSION}
-    container_name: mylar
+    container_name: ${CONTAINER_PREFIX}mylar
     profiles: ["${MYLAR_PROFILE}"]
     networks:
       apps:
@@ -389,7 +389,7 @@ services:
 
   # notifiarr:
   #   image: ghcr.io/notifiarr/notifiarr:${NOTIFIARR_VERSION}
-  #   container_name: notifiarr
+  #   container_name: ${CONTAINER_PREFIX}notifiarr
   #   profiles: ["${NOTIFIARR_PROFILE}"]
   #   networks: [apps, services]
   #   sysctls:

--- a/docker-compose-torrent.yml
+++ b/docker-compose-torrent.yml
@@ -41,13 +41,13 @@ services:
   qbittorrent:
     <<: *limit-downloaders
     image: docker.io/linuxserver/qbittorrent:${QBITTORRENT_VERSION}
-    container_name: qbittorrent
+    container_name: ${CONTAINER_PREFIX}qbittorrent
     depends_on:
       ${VPN_PROVIDER}:
         condition: service_healthy
         restart: true
     profiles: ["${QBITTORRENT_PROFILE}"]
-    network_mode: container:${VPN_PROVIDER}
+    network_mode: container:${CONTAINER_PREFIX}${VPN_PROVIDER}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -75,13 +75,13 @@ services:
   jdownloader2:
     <<: *limit-downloaders
     image: docker.io/jlesage/jdownloader-2:${JDOWNLOADER2_VERSION}
-    container_name: jdownloader2
+    container_name: ${CONTAINER_PREFIX}jdownloader2
     depends_on:
       ${VPN_PROVIDER}:
         condition: service_healthy
         restart: true
     profiles: ["${JDOWNLOADER2_PROFILE}"]
-    network_mode: container:${VPN_PROVIDER}
+    network_mode: container:${CONTAINER_PREFIX}${VPN_PROVIDER}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/docker-compose-vpn.yml
+++ b/docker-compose-vpn.yml
@@ -11,7 +11,7 @@ services:
   gluetun:
     <<: *limit-gluetun
     image: ghcr.io/qdm12/gluetun:${GLUETUN_VERSION}
-    container_name: gluetun
+    container_name: ${CONTAINER_PREFIX}gluetun
     profiles: ["${GLUETUN_PROFILE}"]
     networks:
       wan: {}
@@ -90,7 +90,7 @@ services:
   # ever populates gluetun's config to actually point at it.
   vpn_mock:
     image: docker.io/linuxserver/wireguard:${VPN_MOCK_VERSION}
-    container_name: vpn_mock
+    container_name: ${CONTAINER_PREFIX}vpn_mock
     profiles: ["${VPN_MOCK_PROFILE}"]
     networks:
       wan: {}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -209,6 +209,58 @@ for what was fixed and when.
   merge queues are reported to interact badly with required approvals and
   Renovate, so check that before choosing
 
+## Container names and running two checkouts
+
+- [ ] Make `make start` fail when it creates no containers. It runs
+  `$(COMPOSE) ... up --detach --no-recreate` with no error check, and
+  podman-compose returns zero even when every individual container fails to
+  create, so the target reported success having created nothing at all: 33
+  "the container name is already in use" errors, an empty pod, exit code 0.
+  CI survives that only by accident, because `wire-connections.sh` runs
+  `set -euo pipefail` and dies trying to reach absent apps. The designed gate
+  does not catch it either: `Wait for containers to be ready` greps for
+  containers reporting `starting`, and zero containers means zero matches, so
+  it passes instantly, after which every test hits `skip_if_not_running` and
+  skips. There is no minimum container count assertion anywhere, so an empty
+  stack can produce a green suite. Asserting the started count against the
+  enabled profile set is the fix
+
+- [ ] Say in the documentation that adopting `CONTAINER_PREFIX` on an existing
+  checkout needs a `make down` first, not a `make stop_all`. Stopping leaves
+  the containers in place and podman container names belong to stopped
+  containers too, so a merely stopped checkout still holds every bare name and
+  still blocks the other one. Worse, the teardown ordering in `make down`
+  (which removes gluetun last, because every download client
+  network_mode-depends on it) matches on the prefixed name, so it cannot
+  cleanly remove containers created before the prefix was set. Hit exactly
+  that: `make down` failed on gluetun with "has dependent containers" and
+  needed a second pass
+
+- [ ] Decide whether the Grafana dashboards should follow a prefixed checkout
+  or stay pinned to the deployment. `podman_containers.json` hardcodes
+  `pod_name="pod_docker-torrent-box-with-vpn"` and its `stack` variable lists
+  bare service names as a regex, and PromQL anchors `=~`, so neither matches
+  `dev-qbittorrent` and a prefixed checkout's panels are empty. This is not a
+  mechanical fix: `test_podman_dashboard_container_variable_is_repo_scoped`,
+  `test_podman_dashboard_default_stack_filter_is_repo_only` and
+  `test_podman_dashboard_podman_exporter_queries_are_repo_scoped` assert that
+  hardcoded pod name deliberately, to guarantee the dashboard never shows
+  containers from outside this repository's pod. Deriving the pod from a query
+  variable would weaken exactly that property. The alternative is accepting
+  empty panels in a second checkout, which costs nothing operationally since
+  the deployment is the one being watched
+
+- [ ] Reconcile an existing download client's host when `GLUETUN_SERVICES_IP`
+  changes. `ensure_qbittorrent_client` and its SABnzbd counterpart return early
+  when a client with that implementation already exists, so `make
+  wire_connections` cannot repair a stale address and every arr keeps pointing
+  at the previous one. Running two checkouts makes this sharper rather than
+  merely stale: the address a second checkout inherits is the *other*
+  environment's gateway, so its arrs are aimed at the deployment's download
+  clients and only fail because the two internal networks do not route to each
+  other. Seen live, with every arr in the clone holding 172.28.0.10 while its
+  own gluetun sat at 172.25.0.10
+
 ## Test suite
 
 - [ ] Stop `test_compose_available` failing when one compose flavour is merely

--- a/scripts/rotate-api-keys.sh
+++ b/scripts/rotate-api-keys.sh
@@ -27,6 +27,14 @@ env_value() {
   grep -m1 "^${key}=" .env | cut -d= -f2-
 }
 
+# Container names carry CONTAINER_PREFIX, which is empty for a deployment and
+# set in a second checkout's .env so its containers do not collide with the
+# deployment's on podman's global container namespace. Service names stay
+# unprefixed everywhere else in this script, and this is resolved at the point
+# podman is invoked and nowhere else, so no caller can prefix something twice.
+CONTAINER_PREFIX="$(env_value CONTAINER_PREFIX)"
+cname() { printf '%s%s' "$CONTAINER_PREFIX" "$1"; }
+
 JELLYFIN_HTTP_PORT="$(env_value JELLYFIN_HTTP_PORT)"
 # BaseUrl is a server-wide Jellyfin setting (see wire-connections.sh), not an
 # nginx-only rewrite, so every direct call here needs it too: a bare
@@ -149,7 +157,7 @@ write_secret_file() {
 container_curl() {
   local container_name="$1"
   shift
-  podman exec "$container_name" curl "$@"
+  podman exec "$(cname "$container_name")" curl "$@"
 }
 
 # Stop the listed containers if they exist, remembering which ones were
@@ -174,9 +182,9 @@ stop_container() {
   local c exempt=() normal=() pids=()
   for c in "$@"; do
     if [[ " ${STOP_TIMEOUT_EXEMPT[*]} " == *" ${c} "* ]]; then
-      exempt+=("$c")
+      exempt+=("$(cname "$c")")
     else
-      normal+=("$c")
+      normal+=("$(cname "$c")")
     fi
   done
   # Both batches run concurrently so an exempt container waiting out its
@@ -208,7 +216,7 @@ stop_existing() {
 }
 
 container_running() {
-  podman container inspect -f '{{.State.Running}}' "$1" 2>/dev/null | grep -q '^true$'
+  podman container inspect -f '{{.State.Running}}' "$(cname "$1")" 2>/dev/null | grep -q '^true$'
 }
 
 # podman start can transiently fail with "container state improper" when
@@ -226,7 +234,7 @@ start_containers_retrying() {
     still_remaining=()
     for c in "${remaining[@]}"; do
       container_running "$c" && continue
-      podman start "$c" >/dev/null 2>&1 || still_remaining+=("$c")
+      podman start "$(cname "$c")" >/dev/null 2>&1 || still_remaining+=("$c")
     done
     remaining=("${still_remaining[@]}")
     [[ ${#remaining[@]} -eq 0 ]] && return 0
@@ -622,7 +630,7 @@ rotate_bazarr() {
   echo "[Bazarr] Stopping container and updating auth.apikey in config.yaml..."
   stop_container bazarr
   yq -i ".auth.apikey = \"$new_key\"" "$BAZARR_CONFIG"
-  podman start bazarr >/dev/null
+  podman start "$(cname bazarr)" >/dev/null
 
   write_secret_file "$BAZARR_API_KEY_SECRET" "$new_key"
 
@@ -658,7 +666,7 @@ rotate_lazylibrarian() {
   echo "[LazyLibrarian] Stopping container and writing new api_key..."
   stop_container lazylibrarian
   sed -i "s|^api_key = .*|api_key = ${new_key}|" "$LAZYLIBRARIAN_INI"
-  podman start lazylibrarian >/dev/null
+  podman start "$(cname lazylibrarian)" >/dev/null
 
   local prowlarr_key
   prowlarr_key=$(get_xml_apikey "$PROWLARR_XML")
@@ -682,7 +690,7 @@ rotate_mylar() {
   echo "[Mylar] Stopping container and writing new api_key..."
   stop_container mylar
   sed -i "s|^api_key = .*|api_key = ${new_key}|" "$MYLAR_INI"
-  podman start mylar >/dev/null
+  podman start "$(cname mylar)" >/dev/null
 
   local prowlarr_key
   prowlarr_key=$(get_xml_apikey "$PROWLARR_XML")

--- a/scripts/rotate-api-keys.sh
+++ b/scripts/rotate-api-keys.sh
@@ -208,7 +208,7 @@ stop_existing() {
   STOPPED_CONTAINERS=()
   local c
   for c in "$@"; do
-    if podman container exists "$c" 2>/dev/null; then
+    if podman container exists "$(cname "$c")" 2>/dev/null; then
       stop_container "$c"
       STOPPED_CONTAINERS+=("$c")
     fi
@@ -354,7 +354,7 @@ update_prowlarr_application() {
   local app_name="$2"
   local new_key="$3"
 
-  if ! podman container exists prowlarr 2>/dev/null; then
+  if ! podman container exists "$(cname prowlarr)" 2>/dev/null; then
     echo "[Prowlarr] Container doesn't exist, skipping application update for '${app_name}'."
     return 0
   fi
@@ -410,7 +410,7 @@ update_prowlarr_application() {
 propagate_prowlarr_key() {
   local new_key="$1"
 
-  if ! podman container exists prowlarr 2>/dev/null; then
+  if ! podman container exists "$(cname prowlarr)" 2>/dev/null; then
     return 0
   fi
 
@@ -439,7 +439,7 @@ propagate_prowlarr_key() {
   local entry app scheme port base api_version xml_path app_key indexers
   for entry in "${targets[@]}"; do
     read -r app api_version xml_path <<<"$entry"
-    podman container exists "$app" 2>/dev/null || continue
+    podman container exists "$(cname "$app")" 2>/dev/null || continue
     app_key=$(get_xml_apikey "$xml_path") || continue
     [[ -n "$app_key" ]] || continue
     read -r scheme port base <<<"$(arr_endpoint "$xml_path")"
@@ -472,7 +472,7 @@ propagate_prowlarr_key() {
   # on shutdown like every other INI-configured app in this stack, so the
   # edit needs the same stop-edit-start as rotate_nzbhydra2() already uses
   # for the same file, not a live write.
-  if [[ -f "$LAZYLIBRARIAN_INI" ]] && podman container exists lazylibrarian 2>/dev/null; then
+  if [[ -f "$LAZYLIBRARIAN_INI" ]] && podman container exists "$(cname lazylibrarian)" 2>/dev/null; then
     stop_existing lazylibrarian
     python3 - <<PYEOF
 from pathlib import Path
@@ -879,7 +879,7 @@ rotate_if_enabled() {
     echo "ERROR: ${profile_var}_PROFILE is disabled in .env; not rotating $container_name" >&2
     exit 1
   fi
-  if ! podman container exists "$container_name" 2>/dev/null; then
+  if ! podman container exists "$(cname "$container_name")" 2>/dev/null; then
     if [[ "$TARGET" == "all" ]]; then
       echo "[$container_name] Skipped, container doesn't exist"
       return
@@ -944,7 +944,7 @@ esac
 # a couple of seconds and this one succeeds right after.
 # ---------------------------------------------------------------------------
 
-if podman container exists homepage 2>/dev/null; then
+if podman container exists "$(cname homepage)" 2>/dev/null; then
   echo ""
   echo "Recreating homepage to load the new keys..."
   if ! retry 30 podman-compose --file docker-compose.yml --profile enabled up -d --force-recreate homepage; then

--- a/scripts/rotate-passwords.sh
+++ b/scripts/rotate-passwords.sh
@@ -27,6 +27,14 @@ env_value() {
   grep -m1 "^${key}=" .env | cut -d= -f2-
 }
 
+# Container names carry CONTAINER_PREFIX, which is empty for a deployment and
+# set in a second checkout's .env so its containers do not collide with the
+# deployment's on podman's global container namespace. Service names stay
+# unprefixed everywhere else in this script, and this is resolved at the point
+# podman is invoked and nowhere else, so no caller can prefix something twice.
+CONTAINER_PREFIX="$(env_value CONTAINER_PREFIX)"
+cname() { printf '%s%s' "$CONTAINER_PREFIX" "$1"; }
+
 # Generated password length and whether to include special characters, both
 # configurable via .env (ROTATE_PASSWORD_LENGTH, ROTATE_PASSWORD_SPECIAL_CHARS).
 ROTATE_PASSWORD_LENGTH="$(env_value ROTATE_PASSWORD_LENGTH)"
@@ -209,7 +217,7 @@ mask() {
 container_curl() {
   local container_name="$1"
   shift
-  podman exec "$container_name" curl "$@"
+  podman exec "$(cname "$container_name")" curl "$@"
 }
 
 # Stop the listed containers if they exist, remembering which ones were
@@ -236,9 +244,9 @@ stop_container() {
   local c exempt=() normal=()
   for c in "$@"; do
     if [[ " ${STOP_TIMEOUT_EXEMPT[*]} " == *" ${c} "* ]]; then
-      exempt+=("$c")
+      exempt+=("$(cname "$c")")
     else
-      normal+=("$c")
+      normal+=("$(cname "$c")")
     fi
   done
   # Both batches run concurrently so an exempt container waiting out its
@@ -282,7 +290,7 @@ start_containers_retrying() {
     still_remaining=()
     for c in "${remaining[@]}"; do
       container_running "$c" && continue
-      podman start "$c" >/dev/null 2>&1 || still_remaining+=("$c")
+      podman start "$(cname "$c")" >/dev/null 2>&1 || still_remaining+=("$c")
     done
     remaining=("${still_remaining[@]}")
     [[ ${#remaining[@]} -eq 0 ]] && return 0
@@ -514,7 +522,7 @@ finally:
     conn.close()
 raise SystemExit(0 if updated else 1)
 PYEOF
-    podman start audiobookshelf >/dev/null
+    podman start "$(cname audiobookshelf)" >/dev/null
     # Audiobookshelf has no other host-readable record of its own password
     # (its bcrypt hash lives only in absdatabase.sqlite): persist it the same
     # way qBittorrent/Calibre-Web/Jellyfin do, rather than leaving the new
@@ -530,7 +538,7 @@ PYEOF
     SUMMARY_AUDIOBOOKSHELF_USER="$AUDIOBOOKSHELF_USER"
     SUMMARY_AUDIOBOOKSHELF_NEW="$new_password"
   else
-    podman start audiobookshelf >/dev/null
+    podman start "$(cname audiobookshelf)" >/dev/null
     echo "[Audiobookshelf] No user '${AUDIOBOOKSHELF_USER}' yet, skipping."
     echo "[Audiobookshelf] Complete its setup wizard first, then re-run"
     echo "[Audiobookshelf] 'make rotate_all SERVICE=audiobookshelf'."
@@ -547,7 +555,7 @@ rotate_bazarr() {
   echo "[Bazarr] Stopping container and writing MD5-hashed password to config.yaml..."
   stop_container bazarr
   yq -i ".auth.password = \"$new_md5\"" "$BAZARR_CONFIG"
-  podman start bazarr >/dev/null
+  podman start "$(cname bazarr)" >/dev/null
   SUMMARY_BAZARR_USER="bazarr"
   SUMMARY_BAZARR_NEW="$new_password"
 }
@@ -682,7 +690,7 @@ finally:
     conn.close()
 raise SystemExit(0 if updated else 1)
 PYEOF
-    podman start calibre-web >/dev/null
+    podman start "$(cname calibre-web)" >/dev/null
 
     python3 - <<PYEOF
 from pathlib import Path
@@ -704,7 +712,7 @@ PYEOF
     SUMMARY_CALIBRE_WEB_USER="$CALIBREWEB_USER"
     SUMMARY_CALIBRE_WEB_NEW="$new_password"
   else
-    podman start calibre-web >/dev/null
+    podman start "$(cname calibre-web)" >/dev/null
     echo "[Calibre-Web] No user '${CALIBREWEB_USER}' in app.db, skipping."
   fi
 }
@@ -843,7 +851,7 @@ rotate_lazylibrarian() {
   echo "[LazyLibrarian] Stopping container and writing new http_pass..."
   stop_container lazylibrarian
   sed -i "s|^http_pass = .*|http_pass = ${new_password}|" "$LAZYLIBRARIAN_CONFIG"
-  podman start lazylibrarian >/dev/null
+  podman start "$(cname lazylibrarian)" >/dev/null
   SUMMARY_LAZYLIBRARIAN_USER="lazylibrarian"
   SUMMARY_LAZYLIBRARIAN_NEW="$new_password"
 }
@@ -867,7 +875,7 @@ rotate_mylar() {
   echo "[Mylar] Stopping container and writing new http_password..."
   stop_container mylar
   sed -i "s|^http_password = .*|http_password = ${new_password}|" "$MYLAR_CONFIG"
-  podman start mylar >/dev/null
+  podman start "$(cname mylar)" >/dev/null
   SUMMARY_MYLAR_USER="mylar"
   SUMMARY_MYLAR_NEW="$new_password"
 }
@@ -889,7 +897,7 @@ PYEOF
   echo "[NZBHydra2] Stopping container and writing new bcrypt password hash..."
   stop_container nzbhydra2
   pwHash="{bcrypt}${new_hash}" yq -i '(.auth.users[0].password) = strenv(pwHash)' "$NZBHYDRA_YML"
-  podman start nzbhydra2 >/dev/null
+  podman start "$(cname nzbhydra2)" >/dev/null
 
   SUMMARY_NZBHYDRA2_USER="admin"
   SUMMARY_NZBHYDRA2_NEW="$new_password"
@@ -951,10 +959,10 @@ PYEOF
   # qBittorrent never accepted, leaving the whole stack unable to log in. The
   # jar is the Netscape format, so field 6 is the cookie name and field 7 its
   # value; the name is SID on 5.1.4 and QBT_SID_<port> on 5.2.2.
-  if ! podman exec qbittorrent \
+  if ! podman exec "$(cname qbittorrent)" \
     awk '$6 ~ /SID/ && $7 != "" { found = 1 } END { exit !found }' \
     /tmp/qbt_cookies.txt 2>/dev/null; then
-    podman exec qbittorrent rm -f /tmp/qbt_cookies.txt
+    podman exec "$(cname qbittorrent)" rm -f /tmp/qbt_cookies.txt
     echo "[qBittorrent] Login with the current password was refused, so no session was established. Aborting rotation." >&2
     exit 1
   fi
@@ -966,14 +974,14 @@ PYEOF
     --data-urlencode "json={\"web_ui_password\":\"${new_password}\"}" \
     "https://${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}/api/v2/app/setPreferences")
   if [[ "$set_code" != 2* ]]; then
-    podman exec qbittorrent rm -f /tmp/qbt_cookies.txt
+    podman exec "$(cname qbittorrent)" rm -f /tmp/qbt_cookies.txt
     echo "[qBittorrent] setPreferences answered HTTP ${set_code}, so the new password was not applied. Aborting rotation." >&2
     exit 1
   fi
 
   # The cookie file lives inside the container (curl ran via podman exec),
   # so it must be removed there, not on the host.
-  podman exec qbittorrent rm -f /tmp/qbt_cookies.txt
+  podman exec "$(cname qbittorrent)" rm -f /tmp/qbt_cookies.txt
 
   # The arr apps' DownloadClients tables, and LazyLibrarian's and Mylar's
   # config files, are edited on disk; stop everything in the blast radius so
@@ -1226,13 +1234,13 @@ profile_var_for() {
 }
 
 container_running() {
-  podman container inspect -f '{{.State.Running}}' "$1" 2>/dev/null | grep -q '^true$'
+  podman container inspect -f '{{.State.Running}}' "$(cname "$1")" 2>/dev/null | grep -q '^true$'
 }
 
 container_ready() {
   local container="$1" status
   container_running "$container" || return 1
-  status=$(podman inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" 2>/dev/null)
+  status=$(podman inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$(cname "$container")" 2>/dev/null)
   [[ "$status" == "healthy" || "$status" == "none" ]]
 }
 
@@ -1299,7 +1307,7 @@ prestart_api_containers() {
     if ! profile_enabled "$(profile_var_for "$svc")"; then
       continue
     fi
-    if ! podman container exists "$svc" 2>/dev/null || container_ready "$svc"; then
+    if ! podman container exists "$(cname "$svc")" 2>/dev/null || container_ready "$svc"; then
       continue
     fi
     # A container can already be running but not yet healthy right after
@@ -1613,7 +1621,7 @@ arr_login_ok() {
 # The audiobookshelf image ships no curl, but it is a node image with global
 # fetch; the login check runs node inside the container instead.
 audiobookshelf_login_ok() {
-  podman exec audiobookshelf node -e '
+  podman exec "$(cname audiobookshelf)" node -e '
     const [port, username, password] = process.argv.slice(1);
     fetch(`http://127.0.0.1:${port}/audiobookshelf/login`, {
       method: "POST",
@@ -1691,7 +1699,7 @@ validate_calibre_web() {
     return
   fi
   echo "[Calibre-Web] Not responding after 90s; restarting..."
-  podman restart calibre-web >/dev/null 2>&1 || true
+  podman restart "$(cname calibre-web)" >/dev/null 2>&1 || true
   if retry 300 "[Calibre-Web]" calibre_web_login_ok "$password"; then
     printf "%-14s  OK\n" "calibre-web"
   else
@@ -1711,7 +1719,7 @@ grafana_login_ok() {
 # no longer redirects to /login/. Runs as a single in-container shell script
 # since container_curl only wraps one curl call.
 jdownloader2_login_ok() {
-  podman exec jdownloader2 sh -c '
+  podman exec "$(cname jdownloader2)" sh -c '
     jar=$(mktemp)
     curl -sk -c "$jar" -o /dev/null "https://127.0.0.1:'"${JDOWNLOADER2_HTTP_PORT}"'/"
     curl -sk -b "$jar" -c "$jar" -o /dev/null \
@@ -1816,7 +1824,7 @@ validate_calibre() {
     return
   fi
   echo "[Calibre] Not responding after 90s; restarting the desktop service..."
-  podman exec calibre s6-svc -r /run/service/svc-de >/dev/null 2>&1 || true
+  podman exec "$(cname calibre)" s6-svc -r /run/service/svc-de >/dev/null 2>&1 || true
   if retry 420 "[Calibre]" calibre_login_ok "$password"; then
     printf "%-14s  OK\n" "calibre"
     retry 60 "[Calibre]" calibre_content_server_ok "$password" ||

--- a/scripts/rotate-passwords.sh
+++ b/scripts/rotate-passwords.sh
@@ -265,7 +265,7 @@ stop_existing() {
   STOPPED_CONTAINERS=()
   local c
   for c in "$@"; do
-    if podman container exists "$c" 2>/dev/null; then
+    if podman container exists "$(cname "$c")" 2>/dev/null; then
       STOPPED_CONTAINERS+=("$c")
     fi
   done
@@ -574,7 +574,7 @@ rotate_calibre() {
 
   echo "[Calibre] Stopping calibre and lazylibrarian to update credentials..."
   stop_existing lazylibrarian
-  if podman container exists calibre 2>/dev/null; then
+  if podman container exists "$(cname calibre)" 2>/dev/null; then
     stop_container calibre
   fi
 
@@ -1252,7 +1252,7 @@ container_ready() {
 ensure_running() {
   local container="$1"
   container_ready "$container" && return 0
-  if ! podman container exists "$container" 2>/dev/null; then
+  if ! podman container exists "$(cname "$container")" 2>/dev/null; then
     echo "[$container] Container does not exist; run 'make start' to create it" >&2
     return 1
   fi
@@ -1526,12 +1526,12 @@ if [[ ${#RESTART_CONSUMERS[@]} -gt 0 ]]; then
   recreate_homepage=false
   for consumer in "${RESTART_CONSUMERS[@]}"; do
     if [[ "$consumer" == "homepage" ]]; then
-      if podman container exists homepage 2>/dev/null; then
+      if podman container exists "$(cname homepage)" 2>/dev/null; then
         recreate_homepage=true
       fi
       continue
     fi
-    if podman container exists "$consumer" 2>/dev/null; then
+    if podman container exists "$(cname "$consumer")" 2>/dev/null; then
       existing_consumers+=("$consumer")
     fi
   done

--- a/scripts/seed-vpn-mock.sh
+++ b/scripts/seed-vpn-mock.sh
@@ -134,7 +134,7 @@ until [[ -s "$PEER_CONF" ]]; do
   elapsed=$((elapsed + 2))
   if [[ $elapsed -ge 60 ]]; then
     echo "ERROR: ${PEER_CONF} was not generated after 60s." >&2
-    echo "Check 'podman logs vpn_mock' for details." >&2
+    echo "Check 'podman logs $(env_value CONTAINER_PREFIX)vpn_mock' for details." >&2
     exit 1
   fi
 done

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -58,6 +58,14 @@ env_value() {
   grep -m1 "^${key}=" .env | cut -d= -f2-
 }
 
+# Container names carry CONTAINER_PREFIX, which is empty for a deployment and
+# set in a second checkout's .env so its containers do not collide with the
+# deployment's on podman's global container namespace. Service names stay
+# unprefixed everywhere else in this script, and this is resolved at the point
+# podman is invoked and nowhere else, so no caller can prefix something twice.
+CONTAINER_PREFIX="$(env_value CONTAINER_PREFIX)"
+cname() { printf '%s%s' "$CONTAINER_PREFIX" "$1"; }
+
 LAN_IP="$(env_value LAN_IP)"
 GLUETUN_SERVICES_IP="$(env_value GLUETUN_SERVICES_IP)"
 QBITTORRENT_HTTPS_PORT="$(env_value QBITTORRENT_HTTPS_PORT)"
@@ -121,7 +129,7 @@ get_ini_apikey() {
 container_curl() {
   local container_name="$1"
   shift
-  podman exec "$container_name" curl "$@"
+  podman exec "$(cname "$container_name")" curl "$@"
 }
 
 # Podman's default stop timeout is 10 seconds. The servarr apps shut down
@@ -144,9 +152,9 @@ stop_container() {
   local c exempt=() normal=()
   for c in "$@"; do
     if [[ " ${STOP_TIMEOUT_EXEMPT[*]} " == *" ${c} "* ]]; then
-      exempt+=("$c")
+      exempt+=("$(cname "$c")")
     else
-      normal+=("$c")
+      normal+=("$(cname "$c")")
     fi
   done
   # Both batches run concurrently so an exempt container waiting out its
@@ -381,7 +389,7 @@ ensure_jellyfin_homepage_wiring() {
     container_curl jellyfin -sS --fail -X POST -H "Authorization: MediaBrowser Token=\"${token}\"" \
       -H "Content-Type: application/json" -d "$updated_network_config" \
       "${base_url}/System/Configuration/network" >/dev/null
-    podman restart jellyfin >/dev/null
+    podman restart "$(cname jellyfin)" >/dev/null
   fi
 }
 
@@ -395,16 +403,16 @@ ensure_audiobookshelf_setup() {
   fi
 
   local base_url="http://127.0.0.1:${AUDIOBOOKSHELF_HTTP_PORT}"
-  if ! retry 180 "[Audiobookshelf]" podman exec audiobookshelf wget -qO- "${base_url}/status"; then
+  if ! retry 180 "[Audiobookshelf]" podman exec "$(cname audiobookshelf)" wget -qO- "${base_url}/status"; then
     echo "[Audiobookshelf] Not reachable, skipping."
     return 0
   fi
   local status
-  status=$(podman exec audiobookshelf wget -qO- "${base_url}/status")
+  status=$(podman exec "$(cname audiobookshelf)" wget -qO- "${base_url}/status")
   if [[ "$(echo "$status" | jq -r '.isInit')" != "true" ]]; then
     echo "[Audiobookshelf] Creating initial root user..."
     local init_payload='{"newRoot":{"username":"root","password":"audiobookshelf"}}' # pragma: allowlist secret
-    podman exec audiobookshelf wget -qO- --header='Content-Type: application/json' \
+    podman exec "$(cname audiobookshelf)" wget -qO- --header='Content-Type: application/json' \
       --post-data="$init_payload" "${base_url}/init" >/dev/null
   fi
 
@@ -427,7 +435,7 @@ ensure_audiobookshelf_api_key() {
   local base_url="$1"
   local login_response token
   local login_payload='{"username":"root","password":"audiobookshelf"}' # pragma: allowlist secret
-  login_response=$(podman exec audiobookshelf wget -qO- --header='Content-Type: application/json' \
+  login_response=$(podman exec "$(cname audiobookshelf)" wget -qO- --header='Content-Type: application/json' \
     --post-data="$login_payload" "${base_url}/login" 2>/dev/null)
   token=$(echo "$login_response" | jq -r '.user.token // empty')
   if [[ -z "$token" ]]; then
@@ -440,7 +448,7 @@ ensure_audiobookshelf_api_key() {
   # file's content directly the way ensure_jellyfin_homepage_wiring does; a
   # name unique to this script is enough to tell "already made one" from
   # "never made one, or it's still the seeded placeholder".
-  if podman exec audiobookshelf wget -qO- --header="Authorization: Bearer ${token}" \
+  if podman exec "$(cname audiobookshelf)" wget -qO- --header="Authorization: Bearer ${token}" \
     "${base_url}/api/api-keys" | jq -e '.apiKeys[] | select(.name == "wire-connections")' >/dev/null 2>&1; then
     return 0
   fi
@@ -449,7 +457,7 @@ ensure_audiobookshelf_api_key() {
   local user_id
   user_id=$(echo "$login_response" | jq -r '.user.id')
   local key_response
-  key_response=$(podman exec audiobookshelf wget -qO- --header="Authorization: Bearer ${token}" \
+  key_response=$(podman exec "$(cname audiobookshelf)" wget -qO- --header="Authorization: Bearer ${token}" \
     --header='Content-Type: application/json' \
     --post-data="$(jq -n --arg userId "$user_id" '{name: "wire-connections", userId: $userId, isActive: true}')" \
     "${base_url}/api/api-keys")
@@ -467,7 +475,7 @@ ensure_calibre_content_server_user() {
     echo "[Calibre] Container doesn't exist, skipping."
     return 0
   fi
-  if podman exec calibre calibre-server --userdb "$CALIBRE_USERS_DB_CONTAINER_PATH" \
+  if podman exec "$(cname calibre)" calibre-server --userdb "$CALIBRE_USERS_DB_CONTAINER_PATH" \
     --manage-users -- list 2>/dev/null | grep -qx "$CALIBRE_CONTENT_SERVER_USER"; then
     echo "[Calibre] Content server user already exists, skipping."
     return 0
@@ -476,7 +484,7 @@ ensure_calibre_content_server_user() {
   echo "[Calibre] Creating content server user..."
   local password
   password=$(cat "$CALIBRE_PASSWORD_FILE")
-  podman exec calibre calibre-server --userdb "$CALIBRE_USERS_DB_CONTAINER_PATH" \
+  podman exec "$(cname calibre)" calibre-server --userdb "$CALIBRE_USERS_DB_CONTAINER_PATH" \
     --manage-users -- add "$CALIBRE_CONTENT_SERVER_USER" "$password" >/dev/null
   echo "[Calibre] Done."
 }
@@ -606,7 +614,7 @@ conn.execute(
 conn.commit()
 conn.close()
 PYEOF
-  podman start calibre-web >/dev/null
+  podman start "$(cname calibre-web)" >/dev/null
   echo "[Calibre-Web] Done."
 }
 
@@ -664,7 +672,7 @@ conn.execute(
 conn.commit()
 conn.close()
 PYEOF
-  podman start mylar >/dev/null
+  podman start "$(cname mylar)" >/dev/null
   echo "[Mylar] Done."
 }
 

--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -275,7 +275,7 @@ detect_jellyfin_base_url() {
 }
 
 ensure_jellyfin_setup() {
-  if ! podman container exists jellyfin 2>/dev/null; then
+  if ! podman container exists "$(cname jellyfin)" 2>/dev/null; then
     echo "[Jellyfin] Container doesn't exist, skipping."
     return 0
   fi
@@ -397,7 +397,7 @@ ensure_jellyfin_homepage_wiring() {
 # so this talks to it the same way scripts/rotate-passwords.sh's
 # homepage_http() talks to Homepage for the same reason.
 ensure_audiobookshelf_setup() {
-  if ! podman container exists audiobookshelf 2>/dev/null; then
+  if ! podman container exists "$(cname audiobookshelf)" 2>/dev/null; then
     echo "[Audiobookshelf] Container doesn't exist, skipping."
     return 0
   fi
@@ -471,7 +471,7 @@ ensure_audiobookshelf_api_key() {
 # (verified directly), unlike the desktop GUI/noVNC login, which is already
 # usable from its own committed secret file.
 ensure_calibre_content_server_user() {
-  if ! podman container exists calibre 2>/dev/null; then
+  if ! podman container exists "$(cname calibre)" 2>/dev/null; then
     echo "[Calibre] Container doesn't exist, skipping."
     return 0
   fi
@@ -570,7 +570,7 @@ PYEOF
 }
 
 ensure_calibre_web_setup() {
-  if ! podman container exists calibre-web 2>/dev/null; then
+  if ! podman container exists "$(cname calibre-web)" 2>/dev/null; then
     echo "[Calibre-Web] Container doesn't exist, skipping."
     return 0
   fi
@@ -631,7 +631,7 @@ PYEOF
 # running app's database. Status stays "Paused" so Mylar never actually
 # searches or downloads anything for it.
 ensure_mylar_placeholder_comic() {
-  if ! podman container exists mylar 2>/dev/null; then
+  if ! podman container exists "$(cname mylar)" 2>/dev/null; then
     echo "[Mylar] Container doesn't exist, skipping."
     return 0
   fi
@@ -946,7 +946,7 @@ ensure_jellyfin_connection() {
   local app_name="$1" container="$2" scheme="$3" port="$4" api_ver="$5" api_key="$6"
   local base_url="${scheme}://127.0.0.1:${port}/${app_name}/api/${api_ver}/notification"
 
-  if ! podman container exists jellyfin 2>/dev/null; then
+  if ! podman container exists "$(cname jellyfin)" 2>/dev/null; then
     echo "[$app_name] Jellyfin is not running, skipping its connection."
     return 0
   fi
@@ -1061,7 +1061,7 @@ wire_arr_app() {
   local qbit_category="$6" sab_category="$7"
   local xml="configs/${app_name}/config/config.xml"
 
-  if ! podman container exists "$container" 2>/dev/null; then
+  if ! podman container exists "$(cname "$container")" 2>/dev/null; then
     echo "[$app_name] Container does not exist, skipping."
     return 0
   fi
@@ -1116,7 +1116,7 @@ wire_arr_app() {
 PROWLARR_FAILED=()
 
 wire_prowlarr_apps() {
-  if ! podman container exists prowlarr 2>/dev/null; then
+  if ! podman container exists "$(cname prowlarr)" 2>/dev/null; then
     echo "[Prowlarr] Container doesn't exist (PROWLARR_PROFILE=disabled), skipping."
     return 0
   fi
@@ -1253,7 +1253,7 @@ ensure_prowlarr_indexer_proxy() {
   local prowlarr_api_key="$1"
   local base_url="https://127.0.0.1:${PROWLARR_HTTPS_PORT}/prowlarr/api/v1/indexerproxy"
 
-  if ! podman container exists flaresolverr 2>/dev/null; then
+  if ! podman container exists "$(cname flaresolverr)" 2>/dev/null; then
     echo "[Prowlarr] FlareSolverr container doesn't exist, skipping indexer proxy."
     return 0
   fi
@@ -1453,7 +1453,7 @@ sync_prowlarr_indexers() {
     local missing=() entry app scheme port api_version xml_var key
     for entry in "${targets[@]}"; do
       read -r app scheme port api_version <<<"$entry"
-      podman container exists "$app" 2>/dev/null || continue
+      podman container exists "$(cname "$app")" 2>/dev/null || continue
       xml_var="$(echo "$app" | tr '[:lower:]' '[:upper:]')_XML"
       key=$(get_xml_apikey "${!xml_var}" 2>/dev/null) || continue
       arr_has_indexer "$app" "$scheme" "$port" "$api_version" "$key" || missing+=("$app")
@@ -1496,7 +1496,7 @@ ensure_prowlarr_application() {
   # one entry failing outright used to abort every entry after it too,
   # confirmed live when a wrong URL scheme for one app silently prevented
   # every other app from ever being registered.
-  if ! podman container exists "$container" 2>/dev/null; then
+  if ! podman container exists "$(cname "$container")" 2>/dev/null; then
     echo "[Prowlarr] ${display_name} container doesn't exist, skipping registration."
     return 0
   fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,12 +386,18 @@ def running_containers(docker_client):
     SERVICES registry; the objects still carry their real prefixed names, which is
     what exec and restart need.
     """
-    try:
-        found = docker_client.containers.list(
-            filters={"label": f"com.docker.compose.project={COMPOSE_PROJECT}"}
-        )
-    except Exception:
-        return {}
+    # Deliberately not wrapped in a try/except that returns {}. An empty list is
+    # a legitimate answer, meaning nothing from this project is running, and
+    # every test then skips itself for a stated reason. A raised exception is a
+    # different thing: the podman socket is gone, or the filter is malformed, and
+    # swallowing it produces exactly the same empty inventory as a stopped stack.
+    # The whole suite would then skip and report green while having tested
+    # nothing, which is the failure mode this file has already been bitten by
+    # twice. Let it raise: a collection error is loud and an all-skipped pass is
+    # not.
+    found = docker_client.containers.list(
+        filters={"label": f"com.docker.compose.project={COMPOSE_PROJECT}"}
+    )
     keyed = {}
     for c in found:
         service = (c.labels or {}).get("com.docker.compose.service")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,26 @@ from dotenv import dotenv_values
 REPO_ROOT = Path(__file__).parent.parent
 ENV = dotenv_values(REPO_ROOT / ".env")
 
+# Which checkout's containers this suite is allowed to see, derived the way the
+# Makefile derives it: COMPOSE_PROJECT_NAME when .env sets one, otherwise the
+# directory name. Without this the suite reaches every container on the host,
+# and two checkouts running at once means the tests silently operate on whichever
+# one happens to own the name they looked up. Confirmed live: with a deployment
+# up and this checkout's containers prefixed, `pytest -m containers` reported 57
+# passed against the *deployment's* containers, and the rotation tier restarts
+# what it finds.
+COMPOSE_PROJECT = ENV.get("COMPOSE_PROJECT_NAME") or REPO_ROOT.name
+
+# Prepended to every container_name in the compose files, empty for a normal
+# deployment. Service names are unprefixed, so tests and the SERVICES registry
+# keep naming services and this is the only place that knows the difference.
+CONTAINER_PREFIX = ENV.get("CONTAINER_PREFIX") or ""
+
+
+def container_name(service: str) -> str:
+    """The real container name for a service in this checkout."""
+    return f"{CONTAINER_PREFIX}{service}"
+
 
 def pytest_collection_modifyitems(config, items):
     """Keep every rotation_isolated case for one app on a single xdist worker.
@@ -357,10 +377,26 @@ def docker_client():
 
 @pytest.fixture(scope="session")
 def running_containers(docker_client):
+    """This checkout's running containers, keyed by service name.
+
+    Filtered by the compose project label rather than listing everything on the
+    host, so a second checkout's containers are invisible here even when they are
+    running. Keyed by the `com.docker.compose.service` label rather than the
+    container name, so a CONTAINER_PREFIX never reaches the callers or the
+    SERVICES registry; the objects still carry their real prefixed names, which is
+    what exec and restart need.
+    """
     try:
-        return {c.name: c for c in docker_client.containers.list()}
+        found = docker_client.containers.list(
+            filters={"label": f"com.docker.compose.project={COMPOSE_PROJECT}"}
+        )
     except Exception:
         return {}
+    keyed = {}
+    for c in found:
+        service = (c.labels or {}).get("com.docker.compose.service")
+        keyed[service or c.name] = c
+    return keyed
 
 
 def container_running(name: str, running_containers: dict) -> bool:
@@ -380,7 +416,7 @@ def fresh_container(docker_client, name: str):
     container (rotation, rinse-and-repeat), that container gets a new ID and
     the cached object's exec_run() calls 404 against the old one.
     """
-    return docker_client.containers.get(name)
+    return docker_client.containers.get(container_name(name))
 
 
 def skip_if_not_running_fresh(docker_client, name: str, timeout: int = 60):
@@ -402,7 +438,7 @@ def skip_if_not_running_fresh(docker_client, name: str, timeout: int = 60):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            if docker_client.containers.get(name).status == "running":
+            if docker_client.containers.get(container_name(name)).status == "running":
                 return
         except docker.errors.NotFound:
             pass
@@ -590,7 +626,9 @@ def restart_container(name: str, retries: int = 6, delay: int = 5):
     for _ in range(retries):
         try:
             subprocess.run(  # nosec B607 - podman is a trusted, fixed CLI in this stack
-                ["podman", "restart", name], check=True, capture_output=True
+                ["podman", "restart", container_name(name)],
+                check=True,
+                capture_output=True,
             )
             return
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
# Pull Request

## What

- `container_name` becomes `${CONTAINER_PREFIX}<service>` across all 37 services,
  empty by default, so a deployment's container names are unchanged.
- The download clients' `network_mode: container:${VPN_PROVIDER}` takes the
  prefix. The `depends_on: ${VPN_PROVIDER}:` beside it does not, because that one
  names a service.
- The Makefile's gluetun references take it: the health wait, its exec probe and
  the ordered teardown.
- `tests/conftest.py` now scopes itself to its own checkout, filtering on
  `com.docker.compose.project` and keying on `com.docker.compose.service`.
- The three operational scripts resolve service to container through a `cname()`
  at the point podman is invoked: 12 helper bodies, 30 literal call sites.
- Four findings recorded in `docs/TODO.md` rather than fixed here.

## Why

- **Two checkouts could not run at the same time.** Pods and networks are already
  per project, but podman container names are global and all 37 were bare
  literals, so whichever checkout owned `gluetun`, `sonarr` and the rest held
  them and the other's `make start` created nothing.
- **It failed in the worst available way.** `up --no-recreate` adopts a container
  that already answers to the name, so starting the deployment while a clone's
  containers existed brought the deployment up around the *clone's* gluetun: its
  VPN gateway reported healthy while dialling `172.25.0.11`, the clone's mock
  endpoint. Nothing warned, because from compose's point of view the name
  matched. A clean refusal would have been better. Confirmed live, both
  directions.
- **This stays cheap because service names are untouched.**
  `podman_compose.py:983` sets `aliases_on_container = [service_name]`, so the
  DNS alias comes from the service, not `container_name`. All 37 already matched,
  so nginx's upstreams, Prometheus's scrape targets, Homepage's widget URLs and
  Alloy needed no change at all, and healthchecks talk to 127.0.0.1.
- **The Makefile only surfaced by running it.** The 180 second gluetun health
  wait, the exec probe and the teardown that removes gluetun last (every download
  client `network_mode`-depends on it) all named the container literally. With a
  prefix those miss and `make start` hangs three minutes then fails. Line 322's
  `$(COMPOSE) ... exec -T gluetun` names a service and is left alone.
- **conftest is the safety half, and it matters more than the rest.**
  `running_containers` listed every container on the host with no project filter,
  so with two checkouts up the suite resolved a service to whichever container
  owned the bare name. With the deployment running and this clone prefixed,
  `pytest -m containers` reported **57 passed against the deployment's
  containers**. The rotation tier restarts what it finds and the wiring tier
  writes to it, so that was a hazard, not an inaccuracy, and making coexistence
  possible is what created it. Filtering on the project label and keying on the
  service label means tests and the `SERVICES` registry keep naming services and
  nothing outside conftest knows a prefix exists.
- **Prefixing only where podman is invoked** keeps a caller from prefixing twice.
  `stop_container` still matches `STOP_TIMEOUT_EXEMPT` on the unprefixed name and
  prefixes when building the argument arrays, so that list needed no change.

## References

- Verified with both stacks up simultaneously: 34 containers for the deployment
  on 172.28/29/30 and ports 80/443, 36 for the clone on 172.25/26/27 and ports
  10080/10443. Zero name collisions either side, each gluetun dialling its own
  endpoint, no container on the other project's network, no host port bound
  twice.
- `make wire_connections` ran against the clone with the deployment **provably**
  untouched: its container list and start times were byte identical before and
  after. That is the check that matters, since that script writes download client
  configuration into whatever it finds.
- The clone's read-only tier: 754 passed, 31 skipped, with the deployment running
  throughout. `pytest -m containers` now resolves `sonarr` to `dev-sonarr`, sees
  36 containers, and cannot see the deployment's at all.
- Recorded rather than fixed: `make start` exits zero having created no
  containers and no gate catches it; adopting a prefix on an existing checkout
  needs `make down` not `make stop_all`, because stopped containers keep their
  names; the Grafana dashboards stay pinned to the deployment's pod, and
  unpinning them would weaken the three tests written to keep them pinned;
  `wire-connections.sh` still cannot repair an existing download client's host.
- Follows #95, which separated the networks. That was necessary and, as this
  shows, not sufficient.

https://claude.ai/code/session_01X8GXVNcBeFbVPQtLSbCUGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional container-name prefixes to support running multiple checkouts concurrently without naming conflicts.
  * Preserved existing service names and internal network references.
  * Added configurable startup monitoring timeout and improved stack readiness and failure detection.
  * Updated cleanup, VPN, credential rotation, and connection workflows to recognize prefixed containers.
* **Documentation**
  * Added guidance and follow-up items for prefixed deployments.
* **Tests**
  * Updated container discovery, readiness checks, restarts, and isolation for configurable prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->