### PR TITLE
Judge a start by what is running, not by what compose returned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ COMPOSE_PROJECT_NAME ?= $(notdir $(CURDIR))
 export COMPOSE_PROJECT_NAME
 PODMAN_DOWN_TIMEOUT ?= 60
 
+# How long scripts/assert-stack-started.sh waits for every enabled service to
+# appear before calling the start failed. It polls alongside `compose up` rather
+# than after it, so this bounds the stack, not the known hang in that command.
+STACK_START_TIMEOUT ?= 300
+export STACK_START_TIMEOUT
+
 # Remembers the VPN_ON used by the last successful `make start`, so down/stop/restart
 # match a running stack even when VPN_ON isn't repeated on the command line. An
 # explicit VPN_ON on the command line always wins over the remembered value.
@@ -874,7 +880,17 @@ start: storage_guard permissions_repair
 	@$(COMPOSE) $(COMPOSE_FILES) --profile enabled up --detach --no-recreate gluetun
 	$(call wait_for_gluetun)
 	@echo "Starting all containers..."
-	@$(COMPOSE) $(COMPOSE_FILES) --profile enabled up --detach --no-recreate
+	# Run in the background and judged by what is running, not by whether it
+	# returned. podman-compose answers neither question on its own: it returns 0
+	# when every container failed to create, and intermittently never returns when
+	# they all succeeded. Polling alongside it means a start costs what the stack
+	# actually needs rather than the full bound on the hang, and the assert stops
+	# early once the process is gone since nothing more will appear then.
+	@set -e; \
+	$(COMPOSE) $(COMPOSE_FILES) --profile enabled up --detach --no-recreate & \
+	up_pid=$$!; \
+	trap 'kill $$up_pid 2>/dev/null || true' EXIT; \
+	COMPOSE_UP_PID=$$up_pid ./scripts/assert-stack-started.sh $(COMPOSE_FILES)
 	@echo "$(VPN_ON)" > $(VPN_STATE_FILE)
 
 start_library: storage_guard permissions_repair

--- a/scripts/assert-stack-started.sh
+++ b/scripts/assert-stack-started.sh
@@ -36,6 +36,20 @@ set -uo pipefail
 readonly TIMEOUT="${STACK_START_TIMEOUT:-300}"
 readonly INTERVAL=5
 
+# Validated rather than trusted, because a non-numeric value fails quietly in the
+# worst direction. This script runs under `set -uo pipefail` and deliberately not
+# `set -e`, so `[ "$elapsed" -ge "$TIMEOUT" ]` against a non-number prints
+# "integer expression expected" and returns non-zero, the bound never triggers,
+# and the loop runs until `compose up` happens to exit. A typo in the variable
+# would therefore remove the timeout instead of reporting itself. Zero stays
+# valid: it means check once and report what is already running.
+case "$TIMEOUT" in
+'' | *[!0-9]*)
+  echo "ERROR: STACK_START_TIMEOUT must be a whole number of seconds, got '${TIMEOUT}'." >&2
+  exit 1
+  ;;
+esac
+
 if command -v podman >/dev/null 2>&1; then
   RUNTIME=podman
   if command -v podman-compose >/dev/null 2>&1; then

--- a/scripts/assert-stack-started.sh
+++ b/scripts/assert-stack-started.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Ivan Pinatti
+set -uo pipefail
+
+# Usage: ./scripts/assert-stack-started.sh --file a.yml --file b.yml ...
+#
+# Decides whether the stack came up by looking at what is running, rather than
+# by trusting `compose up --detach` to return. Two separate problems make that
+# necessary, and this is the one check that answers both.
+#
+# `podman-compose up --detach` intermittently never returns even though every
+# container is created and running. CI bounded it at 420s and treated the
+# interrupt as failure, so a stack that was demonstrably up reported a failed
+# build: three consecutive runs across two unrelated branches stalled at
+# "Starting all containers..." with 27, 33 and 33 containers already running.
+# It became consistent rather than occasional when CI started applying
+# .env.tests, which took the service count from 22 to 36.
+#
+# The opposite failure is just as quiet. podman-compose returns 0 even when
+# every individual container fails to create, so `make start` could report
+# success having created nothing at all: 33 "the container name is already in
+# use" errors, an empty pod, exit code 0. Nothing downstream noticed either,
+# because the readiness wait greps for containers reporting "starting" and an
+# empty stack matches none, after which every test skips itself and the suite
+# passes having tested nothing.
+#
+# Comparing the enabled service list against the services actually running
+# replaces both a command's exit status and a grep for absence with the
+# question that was meant all along.
+#
+# Services are matched through the compose project and service labels, not
+# through container names, so this is unaffected by anything that renames a
+# container.
+
+readonly TIMEOUT="${STACK_START_TIMEOUT:-300}"
+readonly INTERVAL=5
+
+if command -v podman >/dev/null 2>&1; then
+  RUNTIME=podman
+  if command -v podman-compose >/dev/null 2>&1; then
+    COMPOSE=(podman-compose)
+  else
+    COMPOSE=(podman compose)
+  fi
+else
+  RUNTIME=docker
+  COMPOSE=(docker compose)
+fi
+
+project="${COMPOSE_PROJECT_NAME:-}"
+if [ -z "$project" ] && [ -f .env ]; then
+  project="$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' .env | head -1 | tr -d '"')"
+fi
+[ -n "$project" ] || project="$(basename "$PWD")"
+
+expected="$("${COMPOSE[@]}" "$@" --profile enabled config --services 2>/dev/null | sort -u)"
+if [ -z "$expected" ]; then
+  echo "ERROR: could not determine which services should be running." >&2
+  echo "'${COMPOSE[*]} ... --profile enabled config --services' returned nothing," >&2
+  echo "so there is no list to check the stack against. Refusing to report success." >&2
+  exit 1
+fi
+expected_count="$(printf '%s\n' "$expected" | wc -l)"
+
+running_services() {
+  "$RUNTIME" ps --filter "label=com.docker.compose.project=${project}" \
+    --format '{{index .Labels "com.docker.compose.service"}}' 2>/dev/null |
+    grep -v '^$' | sort -u
+}
+
+# COMPOSE_UP_PID, when the caller passes one, is a `compose up` still running in
+# the background. Polling alongside it rather than after it is what keeps the
+# known hang from costing the full bound on every start: the loop stops the
+# moment every service is up, whether or not the command has returned.
+#
+# It also gives a fast exit on a genuine failure. Once that process is gone,
+# nothing more is going to appear, so one further poll settles it instead of
+# waiting out the timeout for containers that are never coming.
+up_pid="${COMPOSE_UP_PID:-}"
+elapsed=0
+grace=0
+while :; do
+  missing="$(comm -23 <(printf '%s\n' "$expected") <(running_services))"
+  [ -z "$missing" ] && break
+  if [ -n "$up_pid" ] && ! kill -0 "$up_pid" 2>/dev/null; then
+    [ "$grace" -ge 1 ] && break
+    grace=$((grace + 1))
+  fi
+  [ "$elapsed" -ge "$TIMEOUT" ] && break
+  sleep "$INTERVAL"
+  elapsed=$((elapsed + INTERVAL))
+done
+
+if [ -n "$missing" ]; then
+  echo "ERROR: $(printf '%s\n' "$missing" | wc -l) of ${expected_count} enabled services are not running after ${elapsed}s:" >&2
+  printf '  %s\n' $missing >&2
+  echo >&2
+  echo "Their absence is the failure, whatever 'compose up' reported. Check" >&2
+  echo "'$RUNTIME logs <name>' for one of them, and '$RUNTIME ps --all' for" >&2
+  echo "containers that were created and then exited." >&2
+  exit 1
+fi
+
+echo "All ${expected_count} enabled services are running."

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -323,3 +323,52 @@ def test_generate_homepage_services_tolerates_unowned_output_file(
 
     assert module.main() == 0
     assert "Sonarr" in output_file.read_text()
+
+
+def test_assert_stack_started_refuses_an_empty_service_list(tmp_path):
+    """No service list means nothing was checked, which must not read as success.
+
+    The script decides whether a start worked by comparing the enabled services
+    against the running ones. If the compose invocation yields no services at
+    all, the comparison is vacuous and every service trivially "present", which
+    is the shape of bug this script exists to end rather than to repeat. It has
+    to refuse instead.
+    """
+    empty = tmp_path / "empty-compose.yml"
+    empty.write_text("services: {}\n")
+    result = subprocess.run(
+        [str(SCRIPTS / "assert-stack-started.sh"), "--file", str(empty)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode != 0, (
+        f"an empty service list was accepted: {result.stdout}{result.stderr}"
+    )
+    assert "could not determine which services should be running" in result.stderr
+
+
+def test_assert_stack_started_reports_the_services_it_cannot_find(tmp_path):
+    """A failure names the missing services rather than only a count.
+
+    The message is the whole value of this check when a start goes wrong: the
+    step it replaced reported an exit status and nothing about which containers
+    were absent.
+    """
+    compose = tmp_path / "compose.yml"
+    compose.write_text(
+        "services:\n"
+        "  nothing-of-this-name-is-running:\n"
+        "    image: docker.io/library/alpine:3\n"
+    )
+    result = subprocess.run(
+        [str(SCRIPTS / "assert-stack-started.sh"), "--file", str(compose)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "STACK_START_TIMEOUT": "0"},
+    )
+    assert result.returncode != 0
+    assert "nothing-of-this-name-is-running" in result.stderr, result.stderr

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -372,3 +372,25 @@ def test_assert_stack_started_reports_the_services_it_cannot_find(tmp_path):
     )
     assert result.returncode != 0
     assert "nothing-of-this-name-is-running" in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("value", ["abc", "5s", "-1", "3.5", " "])
+def test_assert_stack_started_rejects_a_non_numeric_timeout(value):
+    """A bad timeout must be reported, not silently remove the bound.
+
+    The script runs under `set -uo pipefail` and deliberately not `set -e`, so an
+    non-number that is never checked makes the `-ge` comparison print "integer expression
+    expected" and return non-zero. The bound would then never trigger and the
+    loop would run until `compose up` happened to exit, which is a typo quietly
+    disabling the timeout rather than announcing itself.
+    """
+    result = subprocess.run(
+        [str(SCRIPTS / "assert-stack-started.sh"), "--file", "docker-compose.yml"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "STACK_START_TIMEOUT": value},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "must be a whole number of seconds" in result.stderr, result.stderr


### PR DESCRIPTION
# Pull Request

## What

- `make start` no longer decides whether the stack came up by looking at
  `compose up --detach`'s exit status. `scripts/assert-stack-started.sh` compares
  the enabled service list against the services actually running.
- The `up` runs in the background and the assertion polls alongside it, so a
  start costs what the stack needs rather than the full bound on a known hang.
- Two cases in `tests/test_scripts.py` cover the refusal on an empty service list
  and the naming of missing services.

**Correction to the commit message.** Its last paragraph says it "retires the
docs/TODO.md item asking for exactly this". That item lives on the
`feat/scope-container-names` branch, not on `main`, so there was nothing to
retire here and no `docs/TODO.md` change is in the diff. The retirement belongs
in that branch when it rebases onto this. The sentence is wrong and a
force-push to correct it was not available.

## Why

- **`compose up --detach` answers neither question it was being asked.**
  - It returns 0 when every container failed to create. Starting a second
    checkout beside a deployment gave 33 "the container name is already in use"
    errors, an empty pod, and exit code 0. Nothing downstream noticed either: the
    readiness step greps for containers reporting `starting`, an empty stack
    matches none, so it passes instantly, and every test then hits
    `skip_if_not_running`. An empty stack could produce a green suite.
  - It also intermittently never returns when every container *was* created and
    is running. That was already documented in the workflow. It went from
    occasional to consistent when CI began applying `.env.tests` and the service
    count went from **22 to 36**: three runs in a row across two unrelated
    branches stalled at "Starting all containers..." with 27, 33 and 33
    containers already up, and CI reported a failed build for a stack that was
    demonstrably fine.
- **Polling alongside rather than after** is what keeps the hang from costing a
  fixed four minutes on every start. The assertion also stops early once the
  `up` process is gone, since nothing further will appear then, so a genuine
  failure does not wait out the timeout either.
- **Matching on the compose project and service labels**, not container names,
  scopes the check to its own checkout and leaves it indifferent to anything that
  renames a container. That matters for the branch that adds a container name
  prefix, which would otherwise conflict with this.
- **An empty expected list is refused, not accepted.** A vacuous comparison makes
  every service trivially present, which is precisely the shape of bug this
  script exists to end rather than to repeat.

## References

- Measured with a single stack and no prefix, which is CI's configuration:
  `make start` returns in **41 seconds** reporting all 36 services running,
  against a 420 second interrupt before. The failure direction was exercised
  too, reporting 34 of 36 missing and naming each one.
- The deployment in the other checkout was stopped for that measurement and
  restored afterwards; its 34 container roster was recorded beforehand and is
  byte identical after.
- This changes `make start` for everyone, not only CI, deliberately: a service
  that does not come up is now a loud failure naming it, where before the target
  exited zero and left you to notice.
- Blocks #98, which cannot merge until the suite passes.

https://claude.ai/code/session_01X8GXVNcBeFbVPQtLSbCUGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stack startup now verifies that all configured services become ready before completing.
  * Added a configurable startup timeout, defaulting to 300 seconds.
  * Startup failures now identify unavailable services and provide clearer diagnostics.
  * Invalid timeout values are rejected with an actionable error.

* **Bug Fixes**
  * Prevented successful startup checks when no Compose services are defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->