### PR TITLE
Give CI the prerequisites the observability stack needs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -471,6 +471,15 @@ jobs:
           # (OpenSSL needs a real IP for the certificate's subjectAltName); any
           # RFC 1918 address works here since nothing on the runner resolves it.
           sed -i 's/^LAN_IP=192.168.1.x/LAN_IP=192.168.1.100/' .env
+          # UID and GID ship as 1000, the common case on a bench and wrong here:
+          # this runner's user is 1001. Three observability services mount the
+          # rootless podman socket at /run/user/${UID}/podman, so a wrong UID
+          # makes that path not exist and podman refuses the container with
+          # "statfs /run/user/1000/podman/podman.sock: no such file or directory".
+          # It went unnoticed until `make start` began reporting which services
+          # failed to come up instead of hanging.
+          sed -i "s/^UID=.*/UID=$(id -u)/" .env
+          sed -i "s/^GID=.*/GID=$(id -g)/" .env
 
       - name: Apply the test profile overrides
         timeout-minutes: 3
@@ -508,7 +517,24 @@ jobs:
         # filtering. So it points at this repo's own credential-free mock
         # WireGuard endpoint instead; see docs/VPN_MOCK.md.
         shell: bash
-        run: make enable_test_profiles
+        run: |
+          make enable_test_profiles
+          # podman_exporter and podman_limits_exporter cannot start here, and it
+          # is the runtime rather than the services: both set userns_mode,
+          # podman-compose puts every service in a pod, and podman 4.9.3 refuses
+          # the combination outright with "--userns and --pod cannot be set
+          # together". CI runs the Ubuntu archive's 4.9.3 deliberately, see the
+          # podman install step above, so this is not a version to chase.
+          #
+          # Disabled here rather than in .env.tests, because they do work on a
+          # bench: verified on podman 5.8.4, where both come up healthy and serve
+          # metrics. `make bootstrap_tests` therefore still exercises them, and
+          # that is where the release gate lives.
+          #
+          # cadvisor stays enabled: it sets no userns_mode and only ever failed
+          # on the UID above.
+          sed -i 's/^PODMAN_EXPORTER_PROFILE=enabled/PODMAN_EXPORTER_PROFILE=disabled/' .env
+          sed -i 's/^PODMAN_LIMITS_EXPORTER_PROFILE=enabled/PODMAN_LIMITS_EXPORTER_PROFILE=disabled/' .env
 
       - name: Read PYTHON_VERSION from .env
         timeout-minutes: 1

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -209,6 +209,21 @@ for what was fixed and when.
   merge queues are reported to interact badly with required approvals and
   Renovate, so check that before choosing
 
+## Observability in CI
+
+- [ ] Get `podman_exporter` and `podman_limits_exporter` running in CI, or record
+  that they never will. Both set `userns_mode`, podman-compose puts every service
+  in a pod, and podman 4.9.3 refuses the combination outright with `--userns and
+  --pod cannot be set together`. CI runs the Ubuntu archive's 4.9.3 deliberately,
+  so the version is not the thing to change. The options are podman-compose's
+  `--in-pod=false`, which alters the topology CI tests against and would break
+  `test_observability`'s assertions on the pod name, or dropping `userns_mode`,
+  which is what lets those exporters read the podman socket as the right
+  identity. Both work on a bench, verified on podman 5.8.4, so
+  `make bootstrap_tests` still covers them: this is a CI coverage gap rather than
+  a broken service. The workflow disables them explicitly, with the reason beside
+  the line
+
 ## Test suite
 
 - [ ] Stop `test_compose_available` failing when one compose flavour is merely

--- a/scripts/enable-test-profiles.sh
+++ b/scripts/enable-test-profiles.sh
@@ -32,4 +32,41 @@ while IFS= read -r line; do
   echo "[${ENV_FILE}] ${line}"
 done <"$OVERRIDES_FILE"
 
+# UID and GID ship as 1000 in .env.example, which is right on a typical bench and
+# wrong anywhere else. Three observability services mount the rootless podman
+# socket from /run/user/${UID}/podman, so a value that is not the invoking user's
+# makes that path not exist and podman refuses the container outright: "statfs
+# /run/user/1000/podman/podman.sock: no such file or directory". Seen on a runner
+# whose user is 1001, where cadvisor, podman_exporter and podman_limits_exporter
+# all failed to be created and `make start` reported 3 of 36 services missing.
+#
+# Derived rather than asked for, because there is no case where a test run wants
+# a UID other than the one invoking it.
+for var_line in "UID=$(id -u)" "GID=$(id -g)"; do
+  key="${var_line%%=*}"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "s|^${key}=.*|${var_line}|" "$ENV_FILE"
+  else
+    printf '%s\n' "$var_line" >>"$ENV_FILE"
+  fi
+  echo "[${ENV_FILE}] ${var_line}"
+done
+
+# podman_exporter and podman_limits_exporter both set userns_mode, podman-compose
+# puts every service in a pod, and podman refuses that combination before version
+# 5 with "--userns and --pod cannot be set together". Disabled on those runtimes
+# rather than left to fail, since a service that cannot be created is not a test
+# result. Both are verified working on podman 5.8.4, so a bench keeps the
+# coverage and `make bootstrap_tests` remains the release gate.
+#
+# Gated on the runtime rather than on a CI environment variable: the limitation
+# belongs to podman's version, and anyone on a 4.x runtime hits it identically.
+podman_major="$(podman version --format '{{.Client.Version}}' 2>/dev/null | cut -d. -f1)"
+if [[ -n "$podman_major" ]] && ((podman_major < 5)); then
+  for key in PODMAN_EXPORTER_PROFILE PODMAN_LIMITS_EXPORTER_PROFILE; do
+    sed -i "s|^${key}=.*|${key}=disabled|" "$ENV_FILE"
+    echo "[${ENV_FILE}] ${key}=disabled (podman ${podman_major}.x cannot set --userns inside a pod)"
+  done
+fi
+
 ./scripts/seed-vpn-mock.sh

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -26,14 +26,34 @@ GRAFANA_PATH = "/admin/grafana/api"
 GRAFANA_USER = env("ADMIN_USER", "admin")
 GRAFANA_PASSWORD = env("ADMIN_PASSWORD", "admin")
 
-EXPECTED_PROMETHEUS_JOBS = {
+# Scrape jobs whose target only exists when a profile is enabled, mapped to the
+# service that provides it. Prometheus's own config is static, so a disabled
+# exporter leaves its job configured and its target permanently down, and
+# asserting every job is up would then fail for a service nobody asked to run.
+# CI disables podman_exporter and podman_limits_exporter because podman 4.9.3
+# refuses userns_mode inside a pod; both run on a bench, so `make
+# bootstrap_tests` still asserts them.
+PROFILE_GATED_PROMETHEUS_JOBS = {
+    "podman": "podman_exporter",
+    "podman_limits_exporter": "podman_limits_exporter",
+}
+
+_ALWAYS_EXPECTED_PROMETHEUS_JOBS = {
     "node_exporter",
-    "podman",
-    "podman_limits_exporter",
     "prometheus",
     "qbittorrent",
     "sabnzbd",
 }
+
+
+def expected_prometheus_jobs() -> set:
+    """The scrape jobs that should be up given which profiles are enabled."""
+    jobs = set(_ALWAYS_EXPECTED_PROMETHEUS_JOBS)
+    for job, service in PROFILE_GATED_PROMETHEUS_JOBS.items():
+        if is_enabled(service):
+            jobs.add(job)
+    return jobs
+
 
 REPO_POD_NAME = "pod_docker-torrent-box-with-vpn"
 
@@ -135,7 +155,7 @@ def test_prometheus_all_targets_up(running_containers, prometheus_url):
     targets = data["data"]["activeTargets"]
     by_job = {t["scrapePool"]: t for t in targets}
 
-    for job in EXPECTED_PROMETHEUS_JOBS:
+    for job in expected_prometheus_jobs():
         assert job in by_job, (
             f"Prometheus scrape job '{job}' not found (known: {list(by_job)})"
         )


### PR DESCRIPTION
# Pull Request

## What

- The workflow derives `UID` and `GID` from `id -u` and `id -g` instead of
  inheriting `.env.example`'s `1000`.
- It disables `PODMAN_EXPORTER_PROFILE` and `PODMAN_LIMITS_EXPORTER_PROFILE`,
  with the reason recorded beside the line.
- `tests/test_observability.py`'s expected Prometheus scrape jobs are derived
  from which profiles are enabled, rather than being a constant.

## Why

#95 enabled the observability profiles in CI and #99 made a failed start report
what was missing instead of hanging. What it reported was **3 of 36 services
never coming up**, for two unrelated reasons that had both been invisible.

- **`UID=1000` is wrong on the runner, whose user is 1001.** cadvisor,
  podman_exporter and podman_limits_exporter each mount the rootless podman
  socket from `/run/user/${UID}/podman`, so a wrong UID makes that path not exist
  and podman refuses the container:
  `statfs /run/user/1000/podman/podman.sock: no such file or directory`. Deriving
  it from `id -u` fixes cadvisor outright.
- **The two exporters need more than that.** Both set `userns_mode`,
  podman-compose puts every service in a pod, and podman 4.9.3 refuses the
  combination: `--userns and --pod cannot be set together`. CI runs the Ubuntu
  archive's 4.9.3 deliberately, so the version is not the thing to change.
- **They are disabled in the workflow, not in `.env.tests`,** because they do work
  on a bench: verified on podman 5.8.4, where both come up healthy and serve
  metrics. `make bootstrap_tests` therefore still exercises them, which is where
  the release gate lives. This is a CI coverage gap, not a broken service.
- **The expected scrape jobs had to stop being a constant.** Prometheus is
  configured statically, so a disabled exporter leaves its job configured and its
  target permanently down; asserting every expected job is up would then fail for
  a service nobody asked to run. Deriving the set from the enabled profiles means
  one test asserts both exporters on a bench and neither in CI.

## References

- Verified in both directions without needing a stack: with both profiles enabled
  the expected set is `node_exporter, podman, podman_limits_exporter, prometheus,
  qbittorrent, sabnzbd`; with both disabled it is `node_exporter, prometheus,
  qbittorrent, sabnzbd`.
- `docs/TODO.md` records the two ways to get those exporters running in CI, both
  with a real cost: podman-compose's `--in-pod=false` changes the topology CI
  tests against and would break `test_observability`'s assertions on the pod
  name, and dropping `userns_mode` removes what lets them read the podman socket
  as the right identity.
- Follows #99, which is what surfaced all of this. Before it, `make start` either
  hung to the 420 second interrupt or would have exited zero, so CI had been
  running with three services absent and no way to tell.
- #98 is waiting on this: its suite has been failing on the stall, not on
  anything of its own.

https://claude.ai/code/session_01X8GXVNcBeFbVPQtLSbCUGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by aligning container user and group settings with the test runner.
  * Adjusted Podman monitoring services for compatibility with supported Podman versions.
  * Updated observability checks to account for services enabled in each environment.

* **Documentation**
  * Documented CI limitations affecting Podman monitoring services and recorded tested configuration alternatives.
  * Updated test-profile setup to automatically configure user permissions and compatible monitoring options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->