### PR TITLE
Raise the integration suite timeout from 20 to 25 minutes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -295,10 +295,15 @@ jobs:
     needs: gate
     if: needs.gate.outputs.authorized == 'true'
     runs-on: ubuntu-latest
-    # 20, from the steps of passing runs summing to about 15 minutes. An earlier
-    # comment here claimed two thirds of headroom, taken from run level
-    # timestamps reading 11 or 12; the steps are the honest measure and this is
-    # nearer a third. It should not come down without shortening the suite.
+    # 25, raised from 20 once the Mylar wait moved from the test's own retry
+    # budget into `wire_connections` (#130 / #132), which pushed an honest run
+    # from 681s to 1093s: two runs against #131's final head both landed at
+    # 18m8s and 18m10s, over 90% of the old 20 minute budget with no headroom
+    # left for normal variance. 25 minutes (1500s) is about a third of
+    # headroom over that 1093s, the same bar this comment stated for the old
+    # value against its own 681s baseline. It should not come down without
+    # shortening the suite, and it should not need raising again unless the
+    # suite grows further.
     #
     # This stays the binding limit and the per-step limits below do not try to
     # replace it. They sum past an hour because each has to allow for its own
@@ -313,7 +318,7 @@ jobs:
     # request that had changed nothing but a comment. Normal variance on a busy
     # runner is wide, so anything close to the observed maximum will fail honest
     # runs more often than it catches real hangs.
-    timeout-minutes: 20
+    timeout-minutes: 25
     # One suite per pull request: a second `/run-tests`, or a push to a bot's
     # branch, supersedes the first rather than standing a competing stack up on
     # the same runner pool. That matters more on the bot path than the comment


### PR DESCRIPTION
## Summary

- Raises `timeout-minutes` on `integration-tests.yml`'s `suite` job from 20 to 25.
- The Mylar wait moved from the test's own retry budget into `wire_connections` (#130, fixed by #132), pushing an honest run from 681s to 1093s. Two runs against #131's final head both landed at 18m8s / 18m10s, over 90% of the old 20 minute budget with no headroom left for normal runner variance, right before the merge queue adds a second such run per pull request against the same ceiling.
- 25 minutes restores about a third of headroom over the new 1093s baseline, the bar the job's own comment already stated for the old value against its own 681s baseline.

## Why no `/run-tests`

This is a workflow metadata change: a `timeout-minutes` value cannot affect the suite's own result, only how long it is allowed to run before being killed. An 18 minute run to prove a number that only matters if something hangs is not worth spending, so this pull request is not asking for one. Deliberate, recorded here so it reads as a decision rather than an oversight.

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] `Code Check`, `Prerequisite Checks`, `Detect Changed Paths`, `Security Reports` pass on the draft
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the integration test suite timeout to accommodate longer-running test execution.
  * Updated related documentation to reflect the revised runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->