### PR TITLE
Fix the in-flight review bug, and correct the merge queue docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,10 +65,10 @@ maintainer will comment for you.
 6. Use `make sanity_fast` for the normal local check path and `make sanity_full`
    for the full repository check path.
 7. Checks run in order rather than all at once, so a cheap failure is not paid
-   for twice: draft, then ready for review, then `/run-tests`, then the merge
-   queue. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for what each stage
-   actually runs and proves, including why the required check on a review is
-   `Review Verified` rather than `CodeRabbit` itself (#114).
+   for twice: draft, then ready for review, then `/run-tests`, then a
+   maintainer merges it. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for
+   what each stage actually runs and proves, including why the required check
+   on a review is `Review Verified` rather than `CodeRabbit` itself (#114).
 
    `/run-check` re-runs the two lint layers against your pull request's
    current head without a new push. `/run-tests` is restricted to the

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,8 +28,7 @@ welcome your pull requests.
 | Open as a **draft** | `Code Check` (the pre-commit hooks) | Fix whatever it reports |
 | **Mark ready for review** | CodeRabbit reviews (it skips drafts); `Review Verified` grades whether it actually did | Address its comments, pushing fixes |
 | Comment **`/run-tests`** | The integration suite, against your PR | Wait for it to go green |
-| Every check green | Added to the merge queue | Wait for the queue's own run to pass |
-| Merge | | |
+| Every check green | A maintainer merges it | If `main` moved in the meantime, update the branch first |
 
 Checks run in this order on purpose, so a cheap failure is never paid for
 twice and the expensive one is spent only on the version being merged. See

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -39,15 +39,16 @@ than restating it differently.
 
 ## Why the days are staggered
 
-This was written while required status checks were `strict` on `main`, the setting that made the
-stagger worth doing on its own: every merge put every other open pull request behind, so each one
-needed a rebase and another full run of the integration suite, roughly fifteen minutes a time.
-Issue #117 records a case where a single small change needed three separate suite runs for this
-reason. `strict` came off in favor of a merge queue (see [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md)),
-which removed that specific rebase cascade, but the stagger stays: the queue still processes one
-entry at a time, so opening every ecosystem's pull requests on the same day would still queue them
-behind each other for a maintainer's attention and for a runner's worth of the queue's own suite
-run, even without a rebase forcing it.
+Required status checks are `strict` on `main`, which is the setting that makes the stagger worth
+doing: every merge puts every other open pull request behind, so each one needs a rebase and
+another full run of the integration suite, roughly fifteen minutes a time. Issue #117 records a
+case where a single small change needed three separate suite runs for this reason. A merge queue
+would remove that rebase cascade, and is the tracked intent, but it is not enabled: see
+[docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for why. Until it is, the stagger is what keeps this
+from compounding into one bad day, spreading the ecosystems and groups across the week instead of
+opening every one of their pull requests at once and letting the first merge rebase the rest,
+which would trigger another round of runs, which would produce another merge that rebases what is
+left again.
 
 ## The grouping rationale
 

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -332,11 +332,10 @@ What is placed against it instead:
   [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for the three lanes
   `Review Verified` actually grades and why a green `CodeRabbit` check was not
   evidence of a review in the first place.
-- **The suite itself**, which has to pass on the exact commit that merges: the
-  pull request's own head, and again, against a throwaway merge commit, in the
-  merge queue. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for why the
-  queue exists and what replacing `strict` required status checks with it
-  trades away.
+- **The suite itself**, which has to pass on the pull request's own head
+  before it merges. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for the
+  merge queue this is meant to gain a second, throwaway-commit run through,
+  and why that is not enabled yet.
 
 What remains, and is accepted: the two bot identities are trusted to be
 themselves, and an upstream release that survives seven days, produces a

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -31,10 +31,13 @@ actually being merged, rather than after every push. See
 [docs/CONTRIBUTING.md](CONTRIBUTING.md) for the comment mechanics
 (`/run-check` for the lint layers alone, the maintainer allowlist, and so on).
 
-Once every required check reads green, GitHub adds the pull request to the
-**merge queue** on its own, and it merges once the queue's own run of that
-same check set passes on the commit the queue actually builds. See "The merge
-queue" below for why that extra run exists and what it is trading against.
+Once every required check reads green, a maintainer merges it. `main`
+currently requires `strict` status checks, meaning the branch has to be up to
+date with `main` first; if another pull request has merged in the meantime,
+that means a `gh pr update-branch` (or an equivalent rebase) before merging,
+which dismisses the existing approval and re-runs the mechanical checks and
+the review on the new head. See "The merge queue, and why it isn't one yet"
+below for why this is the current state rather than the intended one.
 
 ## A dependency bot pull request
 
@@ -62,10 +65,13 @@ merge on their own:
    for `Pin Only` to read `success` and then supplies the approving review
    branch protection requires. A diff that is not pin-only gets no approval
    and waits for a person, same as a major bump does.
-4. **GitHub merges it** once every required check, `Review Verified` and the
-   merge queue's own run included, is green. Renovate arms auto-merge itself
-   when it opens the pull request; the workflow arms it on the Dependabot
-   path, since Dependabot cannot.
+4. **GitHub merges it** once every required check, `Review Verified` included,
+   is green. Renovate arms auto-merge itself when it opens the pull request;
+   the workflow arms it on the Dependabot path, since Dependabot cannot.
+   `main`'s `strict` requirement applies here too: whether GitHub's own
+   auto-merge keeps a bot pull request current against `main` on its own, or
+   this still needs each one rebased in turn the way a human pull request
+   does, has not been observed directly and is not asserted here either way.
 
 `Review Verified` is not skipped here, and that is deliberate: see the next
 section for what a pin-only diff actually earns it.
@@ -143,33 +149,38 @@ Read the reason beside a `CodeRabbit` check, not its color, if you are
 looking at it directly; `Review Verified` is what makes that reading a
 required check rather than a habit a person has to remember.
 
-## The merge queue
+## The merge queue, and why it isn't one yet
 
-`main` used to require `strict` status checks: a pull request had to be
-rebased onto the current `main` before it could merge. That guarantee is real
-for a stack whose suite stands the whole thing up, but the cost compounded
-with every dependency bot pull request in flight, since one merge invalidated
-every other open pull request's checks and each one needed a fresh rebase and
-a fresh twelve-minute run to catch back up (#117).
+`main` requires `strict` status checks today: a pull request has to be
+rebased onto the current `main` before it can merge. That guarantee is real
+for a stack whose suite stands the whole thing up, but the cost compounds
+with every dependency bot pull request in flight, since one merge invalidates
+every other open pull request's checks and each one needs a fresh rebase and
+a fresh run to catch back up (#117).
 
-A merge queue replaces `strict` rather than sitting alongside it. It tests a
-throwaway merge commit against the current `main` instead of moving a pull
-request's own head, so the "tested against what it lands on" guarantee still
-holds without a pull request's checks ever being invalidated by someone
-else's merge. Every context in the table above runs a second time, against
-that commit, before anything actually merges: `Code Check`, `Prerequisite
-Checks`, `Detect Changed Paths`, `Tests Verified`, `Pin Only` and `Review
-Verified`. The PR-stage suite run stays required exactly as it is; the queue
-run is an addition, because a dependency bot's approval has to carry test
-evidence behind it, and the queue commit is not the commit that evidence was
-originally read on.
+A merge queue is the intended fix, and it is not enabled. GitHub refuses the
+`merge_queue` ruleset rule on a repository owned by a personal account,
+confirmed empirically: the identical ruleset payload that GitHub rejects here
+with `422 Invalid rule 'merge_queue'` was accepted, active, on a repository
+inside a free organization. This repository is owned by a personal account,
+so the queue stays blocked on that until something changes, tracked on #117.
+Moving this specific repository into an organization is not a decision that
+has been made; an organization migration is being rehearsed separately, on a
+different repository, and has not been approved here.
 
-There is deliberately no post-merge canary on `main` and no revert-based
-recovery. `main` has to be green by construction, which is the whole reason
-every required check runs again on the queue's own commit instead of trusting
-each pull request's copy of them. See [docs/TESTING.md](TESTING.md) for the
-full reasoning, including why selective or per-service testing was
-considered and rejected as a cheaper alternative to the queue.
+Once a queue can be enabled, the design is unchanged from what was built for
+it: it would test a throwaway merge commit against the current `main` instead
+of moving a pull request's own head, so the "tested against what it lands on"
+guarantee `strict` buys today would still hold without a pull request's
+checks ever being invalidated by someone else's merge, and every context in
+the table above would run a second time against that commit before anything
+actually merges. `strict` staying on until then is the safe direction to fail
+in: the alternative, dropping it with nothing in its place, would mean a pull
+request could merge having only ever been tested against a base it is no
+longer on, which is not decorative for a suite that stands the whole stack
+up. See [docs/TESTING.md](TESTING.md) for the fuller reasoning, including why
+selective or per-service testing was considered and rejected as a cheaper
+alternative to a queue.
 
 ## What blocks, and what clears it
 
@@ -192,13 +203,21 @@ intervention.
   failing something else, has a merge conflict, or already has an unresolved
   thread of its own, since a review cannot fix any of those and the quota slot
   would be wasted.
-- **A pull request behind on `main`.** The merge queue tests it fresh against
-  the current `main` rather than requiring a rebase, which is the entire
-  point of dropping `strict`.
-- **A rejected bot pull request that later becomes mergeable.** Ejection from
-  the merge queue does not disable a pull request's auto-merge; GitHub
-  re-enqueues it once the blocking condition clears, the same way the hourly
-  re-grade above clears a bad `Review Verified` run without a person acting.
+
+  The quota itself is worth meeting here rather than being surprised by it:
+  this repository is on CodeRabbit's Open Source plan, which scales the
+  included review count with the repository's star count rather than holding
+  it fixed. The live figure, read directly off a review on #131, is **2
+  included reviews per hour**. #114's own text quotes "up to 10 included
+  reviews per hour" from an earlier check; that was the trial's behavior, not
+  this plan's, and is stale. At 2 an hour, pushing a fix and then pushing
+  another fix to that fix can exhaust the quota for the rest of the hour, and
+  the only recovery is time or the hourly nudge above, never another push.
+- **A rejected bot pull request that later becomes mergeable.** GitHub does
+  not disable a pull request's auto-merge just because it currently fails a
+  required check; it re-evaluates automatically once the blocking condition
+  clears, the same way the hourly re-grade above clears a bad
+  `Review Verified` run without a person acting.
 
 **Needs a person:**
 
@@ -212,6 +231,12 @@ intervention.
 - **A major dependency bump.** No automatic approval either way, by design.
 - **A genuine test failure or merge conflict.** Neither self-heals; someone
   has to change the code.
+- **A human pull request behind on `main`, while there is no merge queue.**
+  `strict` requires the branch to be current, so a maintainer runs
+  `gh pr update-branch` (or an equivalent rebase); this dismisses the
+  approval and spends a `Review Verified` review cycle on the new head. This
+  is exactly the churn #117 exists to remove, and it stays a manual step
+  until the merge queue above can be enabled.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,20 +131,21 @@ overrides each pass's own filter rather than combining with it. Invoke
 `tests/.venv/bin/pytest -m security` directly instead when you want just
 one marker.
 
-## Why the suite also runs in a merge queue
+## Why a merge queue is the goal, not selective testing
 
-`main` required `strict` status checks until #117: a pull request had to be
-up to date with the current `main` before it could merge, so every merge put
-every other open pull request behind and each of those needed a rebase and a
-fresh suite run to catch back up. That got worse as this stack grew, not
+`main` requires `strict` status checks (#117): a pull request has to be up to
+date with the current `main` before it can merge, so every merge puts every
+other open pull request behind and each of those needs a rebase and a fresh
+suite run to catch back up. That has gotten worse as this stack grew, not
 better: the suite now starts 34 services rather than 22, since CI began
 applying `.env.tests` and the observability profiles came on, so a rerun costs
 more wall clock than it used to, and the number of open pull requests the
 churn multiplies against is driven by Renovate and Dependabot, which are
 deliberately scheduled to spread bumps across the week rather than land them
-one at a time. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for what
-replaced `strict`, why the two are paired, and what runs against the queue's
-own commit; this section covers only why a cheaper alternative was rejected.
+one at a time. See [docs/MERGE_PIPELINE.md](MERGE_PIPELINE.md) for the merge
+queue this is meant to be replaced with, and why it is not enabled yet; this
+section covers only why a cheaper alternative to a queue, running fewer tests
+rather than fewer times, was rejected.
 
 Selective or per-service testing (running only the tests a change plausibly
 touches, rather than the whole suite) was considered as a cheaper answer to

--- a/scripts/coderabbit-review-verdict.py
+++ b/scripts/coderabbit-review-verdict.py
@@ -46,14 +46,19 @@ alongside that cannot stall the happy path.
 
 3. Everything else, human authored or a bot pull request whose diff already
 failed the pin-only assertion, is `success` only when the latest `CodeRabbit`
-status description is exactly `Review completed`. Absent is `pending`,
-meaning a review has been asked for and not yet returned. Anything else
-present, `Review rate limited`, any `Review skipped: ...` description reaching
-this lane (a non-bot pull request is never a draft by the time this runs,
-since lane 1 already caught that), an error state, or a description this has
-never seen before, is `failure`. No exceptions here: this lane is where the
-three unreviewed merges happened, and a status this script does not recognize
-is exactly the shape a future change to CodeRabbit's wording would take.
+status description is exactly `Review completed`. Absent, `Review queued`, or
+`Review in progress` is `pending`: a review that has been asked for and not
+yet returned, or is actively running, has not declined anything, and reading
+it as a failure would turn every ordinary review's opening minutes into a red
+required check for no reason. Anything else present, `Review rate limited`,
+any `Review skipped: ...` description reaching this lane (a non-bot pull
+request is never a draft by the time this runs, since lane 1 already caught
+that), an error state, or a description this has never seen before, is
+`failure`. No exceptions there: this lane is where the three unreviewed
+merges happened, and a status this script does not recognize is exactly the
+shape a future change to CodeRabbit's wording would take, so only the two
+known in-flight strings above move to `pending`; nothing else gets the
+benefit of the doubt.
 
 Fails closed throughout. An unset or unrecognized `pin_only_state` for a bot
 pull request is treated as "not yet known" rather than "assume clean", which
@@ -71,6 +76,14 @@ import sys
 # check is repeated here anyway, because trusting an upstream filter to have
 # been applied correctly is how #114 happened in the first place.
 BOTS = frozenset({"renovate[bot]", "dependabot[bot]"})
+
+# CodeRabbit's own in-flight states, observed live on real pull requests.
+# Neither is a decline: a review that is queued or actively running has not
+# read the diff and returned an answer yet, which is exactly what `pending`
+# is for. Treating either as `failure` was the bug found on #133, where
+# `Review Verified` read red for the several minutes CodeRabbit was still
+# working, on the first pull request the required gate ever ran against.
+IN_FLIGHT_DESCRIPTIONS = frozenset({"Review queued", "Review in progress"})
 
 
 def decide(data: dict) -> tuple[str, str]:
@@ -100,6 +113,8 @@ def decide(data: dict) -> tuple[str, str]:
         return "pending", "waiting for a CodeRabbit review"
     if description == "Review completed":
         return "success", 'CodeRabbit reports "Review completed"'
+    if description in IN_FLIGHT_DESCRIPTIONS:
+        return "pending", f'CodeRabbit reports "{description}"'
     return "failure", f'CodeRabbit reports "{description}", which is not a review'
 
 

--- a/tests/test_coderabbit_review_verdict.py
+++ b/tests/test_coderabbit_review_verdict.py
@@ -200,6 +200,33 @@ def test_no_status_yet_is_pending_not_a_pass():
     assert _outputs(result)["state"] == "pending"
 
 
+def test_review_queued_is_pending_not_failure():
+    # CodeRabbit's own in-flight state. Found live on #133, the first pull
+    # request the required gate ever ran against: a review that has not
+    # returned an answer yet has not declined one either.
+    result = _run(
+        {
+            "is_draft": False,
+            "author": "a-human",
+            "is_fork": False,
+            "coderabbit_description": "Review queued",
+        }
+    )
+    assert _outputs(result)["state"] == "pending"
+
+
+def test_review_in_progress_is_pending_not_failure():
+    result = _run(
+        {
+            "is_draft": False,
+            "author": "a-human",
+            "is_fork": False,
+            "coderabbit_description": "Review in progress",
+        }
+    )
+    assert _outputs(result)["state"] == "pending"
+
+
 def test_rate_limited_fails_instead_of_passing():
     # This is the actual bug: #86, #87 and #88 all merged on this exact
     # description reading as success.


### PR DESCRIPTION
## Summary

Three corrections, batched to spend one CodeRabbit review slot rather than three (the quota is 2/hour, see below).

### a. Fix the verdict bug

`Review queued` and `Review in progress` fell into `scripts/coderabbit-review-verdict.py`'s catch-all `failure` branch. Found live on #133, the first pull request the required `Review Verified` gate ever ran against: it read red for the several minutes CodeRabbit was still actively reviewing, not because anything declined. Neither state is a decline, so both now read `pending`. Everything else genuinely unrecognized still fails closed to `failure`, unchanged: only these two known in-flight strings move. Added test cases for both.

### b. Record the real CodeRabbit quota

The repository is on CodeRabbit's Open Source plan, which scales the included review count with star count rather than holding it fixed. The live figure, read directly off a review on #131, is **2 included reviews per hour**. #114 quotes "up to 10 included reviews per hour", which was trial behavior and is stale. Recorded in `docs/MERGE_PIPELINE.md`'s self-healing section, next to the hourly nudge that has to operate within it, so a maintainer meets the number before being surprised by it. Will comment on #114 with the correction once this lands.

### c. Correct `docs/MERGE_PIPELINE.md`, which was wrong in public

It described a merge queue as enabled and `strict` as removed. Neither is true: GitHub refuses the `merge_queue` ruleset rule on a repository owned by a personal account, confirmed empirically against an identical payload accepted, active, on a repository inside a free organization. `strict: true` is live and there is no queue. Rewrote the affected sections to say so plainly, state the queue as the tracked intent behind #117 rather than a decision already made, and note that moving this repository into an organization has not been approved, only rehearsed separately on a different repository. Carried the same one-line correction into `CONTRIBUTING.md`, `TESTING.md` and `HARDENING.md`, which each had a mention assuming the queue existed.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `pytest -m scripts` passes, including 2 new test cases for the in-flight fix (19 total in that file)
- [ ] CI: `Code Check`, `Prerequisite Checks`, `Detect Changed Paths`, `Security Reports`, `Pin Only`, `Review Verified` on the draft
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution, testing, hardening, dependency-update, and merge-pipeline guidance to reflect the current strict-check workflow.
  * Clarified review, recovery, rebasing, merge, and merge-queue behavior, including current limitations and planned direction.

* **Bug Fixes**
  * Pull requests with CodeRabbit reviews queued or in progress now remain pending instead of being marked as failed.

* **Tests**
  * Added coverage for queued and in-progress review statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->